### PR TITLE
Update CI build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             # use old linux so that the shared library versioning is more portable
             artifact_name: floss
             asset_name: linux


### PR DESCRIPTION
Ubuntu 16.04 LTS virtual environment is deprecated.
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/
Reference: https://github.com/mandiant/flare-floss/runs/3712986723