### PR TITLE
add tightloop string extraction

### DIFF
--- a/floss/decoding_manager.py
+++ b/floss/decoding_manager.py
@@ -74,7 +74,7 @@ def get_map_size(emu):
     size = 0
     for mapva, mapsize, mperm, mfname in emu.getMemoryMaps():
         mapsize += size
-    return size
+    return mapsize
 
 
 class MapsTooLargeError(Exception):

--- a/floss/features/extract.py
+++ b/floss/features/extract.py
@@ -24,7 +24,7 @@ SECURITY_COOKIE_BYTES_DELTA = 0x40
 
 SHIFT_ROTATE_INS = (INS_SHL, INS_SHR, INS_ROL, INS_ROR)
 
-logger = logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def extract_insn_nzxor(f, bb, insn):

--- a/floss/features/features.py
+++ b/floss/features/features.py
@@ -85,16 +85,23 @@ class Arguments(Feature):
 
 
 class TightLoop(Feature):
+    # basic block (BB) that jumps to itself
+
     weight = HIGH
 
     def __init__(self, startva, endva):
-        super(TightLoop, self).__init__((startva, endva))
+        super(TightLoop, self).__init__((f"0x{startva:x}", f"0x{endva:x}"))
 
         self.startva = startva
         self.endva = endva
 
     def score(self):
         return 1.0
+
+
+class KindaTightLoop(TightLoop):
+    # BB that jumps to itself via one intermediate BB
+    pass
 
 
 class Mnem(Feature):

--- a/floss/results.py
+++ b/floss/results.py
@@ -13,6 +13,11 @@ from dataclasses import field
 from pydantic.dataclasses import dataclass
 
 
+class StringEncoding(str, Enum):
+    ASCII = "ASCII"
+    UTF16LE = "UTF-16LE"
+
+
 @dataclass(frozen=True)
 class StackString:
     """
@@ -50,11 +55,16 @@ class StackString:
 
     function: int
     string: str
+    encoding: StringEncoding
     program_counter: int
     stack_pointer: int
     original_stack_pointer: int
     offset: int
     frame_offset: int
+
+
+class TightString(StackString):
+    pass
 
 
 class AddressType(str, Enum):
@@ -83,11 +93,6 @@ class DecodedString:
     decoding_routine: int
 
 
-class StringEncoding(str, Enum):
-    ASCII = "ASCII"
-    UTF16LE = "UTF-16LE"
-
-
 @dataclass(frozen=True)
 class StaticString:
     """
@@ -111,6 +116,7 @@ class Metadata:
     date: datetime.datetime = datetime.datetime.now()
     analysis: Dict[str, Dict] = field(default_factory=dict)
     enable_stack_strings: bool = True
+    enable_tight_strings: bool = True
     enable_decoded_strings: bool = True
     enable_static_strings: bool = True
 
@@ -118,6 +124,7 @@ class Metadata:
 @dataclass
 class Strings:
     stack_strings: List[StackString] = field(default_factory=list)
+    tight_strings: List[TightString] = field(default_factory=list)
     decoded_strings: List[DecodedString] = field(default_factory=list)
     static_strings: List[StaticString] = field(default_factory=list)
 

--- a/floss/tightstrings.py
+++ b/floss/tightstrings.py
@@ -1,0 +1,119 @@
+import logging
+from typing import Iterable
+from itertools import chain
+
+import tqdm
+import viv_utils
+import tqdm.contrib.logging
+
+import floss.utils
+import floss.features.features
+from floss import stackstrings
+from floss.results import TightString, StaticString
+from floss.strings import extract_ascii_strings, extract_unicode_strings
+from floss.stackstrings import StackstringContextMonitor
+
+logger = logging.getLogger(__name__)
+
+
+class TightstringContextMonitor(StackstringContextMonitor):
+    def __init__(self, vw, sp, tloops):
+        super(TightstringContextMonitor, self).__init__(vw, sp, [])
+        self.tloop_startvas = [t.startva for t in tloops]
+        self.tloop_endvas = [t.endva for t in tloops]
+        # store FP stackstrings before tightstring loop executes
+        self.pre_ctx_strings = set()
+        logger.debug(" stavas: %s", ", ".join(map(hex, self.tloop_startvas)))
+        logger.debug(" endvas: %s", ", ".join(map(hex, self.tloop_endvas)))
+
+    def apicall(self, emu, op, pc, api, argv):
+        pass
+
+    def prehook(self, emu, op, startpc):
+        if startpc in self.tloop_startvas:
+            try:
+                stack_buf = self.get_call_context(emu, op).stack_memory
+            except ValueError as e:
+                logger.debug(str(e))
+                return
+
+            self.pre_ctx_strings.update(map(lambda s: s.string, floss.strings.extract_ascii_strings(stack_buf)))
+            self.pre_ctx_strings.update(map(lambda s: s.string, floss.strings.extract_unicode_strings(stack_buf)))
+
+            # only save one context per tightloop
+            self.tloop_startvas.remove(startpc)
+
+    def posthook(self, emu, op, endpc):
+        if endpc in self.tloop_endvas:
+            logger.debug("extracting context at endpc: 0x%x", endpc)
+            self.extract_context(emu, op)
+
+            # only extract once at tightloop end
+            self.tloop_endvas.remove(endpc)
+
+
+def extract_tightstring_contexts(vw, fva, tloops):
+    emu = floss.utils.make_emulator(vw)
+    monitor = TightstringContextMonitor(vw, emu.getStackCounter(), tloops)
+    driver = viv_utils.emulator_drivers.FunctionRunnerEmulatorDriver(emu)
+    driver.add_monitor(monitor)
+    driver.runFunction(fva, maxhit=0x100, maxrep=0x100, func_only=True)
+    return monitor.ctxs, monitor.pre_ctx_strings
+
+
+def extract_tightstrings(vw, tightloop_functions, quiet=False):
+    """
+    Extracts tightstrings from functions that contain tight loops.
+    Tightstrings are a special form of stackstrings. Their bytes are loaded on the stack and then modified in a
+    tight loop. To extract tightstrings we use a mix between the string decoding and stackstring algorithms.
+
+    To reduce computation time we only run this on previously identified functions that contain tight loops.
+
+    :param vw: The vivisect workspace
+    :param tightloop_functions: functions containing tight loops
+    :param quiet: do NOT show progress bar
+    :rtype: Generator[StackString]
+    """
+    # TODO add test sample(s) and tests
+    pbar = tqdm.tqdm
+    if quiet:
+        # do not use tqdm to avoid unnecessary side effects when caller intends
+        # to disable progress completely
+        pbar = lambda s, *args, **kwargs: s
+
+    pb = pbar(tightloop_functions.items(), desc="extracting tightstrings", unit=" functions")
+    with tqdm.contrib.logging.logging_redirect_tqdm(), floss.utils.redirecting_print_to_tqdm():
+        for fva, tloops in pb:
+            fva_s = f"0x{fva:x}"
+            pb.set_description(f"extracting tightstrings from {fva_s}")
+            with floss.utils.timing(fva_s):
+                logger.debug("extracting tightstrings from function: 0x%x", fva)
+                ctxs, pre_ctx_strings = extract_tightstring_contexts(vw, fva, tloops)
+                logger.debug("pre_ctx strings: %s", pre_ctx_strings)
+                for ctx in ctxs:
+                    logger.debug(
+                        "extracting tightstring at checkpoint: 0x%x stacksize: 0x%x", ctx.pc, ctx.init_sp - ctx.sp
+                    )
+                    for s in chain(
+                        floss.strings.extract_ascii_strings(ctx.stack_memory),
+                        floss.strings.extract_unicode_strings(ctx.stack_memory),
+                    ):
+
+                        # TODO sanitize/cleanup string?
+                        #  pVA and other prefixes
+                        # if floss.utils.is_fp_string(s.string):
+                        #     continue
+                        # stripped_string = floss.utils.strip_string(s.string)
+
+                        # TODO remove dups, e.g. in e5f5ad
+
+                        if s.string not in pre_ctx_strings:
+                            frame_offset = (ctx.init_sp - ctx.sp) - s.offset - stackstrings.getPointerSize(vw)
+                            ts = TightString(
+                                fva, s.string, s.encoding, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset
+                            )
+                            # TODO option/format to log quiet and regular, this is verbose output here currently
+                            logger.info(
+                                "%s [%s] in 0x%x at frame offset 0x%x", ts.string, ts.encoding, fva, ts.frame_offset
+                            )
+                            yield ts

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -15,7 +15,7 @@ from .const import MEGABYTE
 STACK_MEM_NAME = "[stack]"
 
 
-logger = logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def make_emulator(vw) -> Emulator:

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -1,14 +1,21 @@
 # Copyright (C) 2017 Mandiant, Inc. All Rights Reserved.
-
 import re
+import time
+import inspect
+import logging
+import contextlib
 from collections import OrderedDict
 
+import tqdm
 import tabulate
 from envi import Emulator
 
 from .const import MEGABYTE
 
 STACK_MEM_NAME = "[stack]"
+
+
+logger = logger = logging.getLogger(__name__)
 
 
 def make_emulator(vw) -> Emulator:
@@ -19,7 +26,12 @@ def make_emulator(vw) -> Emulator:
     remove_stack_memory(emu)
     emu.initStackMemory(stacksize=int(0.5 * MEGABYTE))
     emu.setStackCounter(emu.getStackCounter() - int(0.25 * MEGABYTE))
-    emu.setEmuOpt("i386:reponce", False)  # do not short circuit rep prefix
+    # do not short circuit rep prefix
+    try:
+        emu.setEmuOpt("i386:repmax", 256)  # 0 == no limit on rep prefix
+    except Exception:
+        # TODO remove once vivisect#465 is included in release
+        emu.setEmuOpt("i386:reponce", False)
     return emu
 
 
@@ -122,3 +134,38 @@ def strip_string(s):
     for reg in (FP_FILTER_PREFIXES, FP_FILTER_SUFFIXES):
         s = re.sub(reg, "", s)
     return s
+
+
+@contextlib.contextmanager
+def redirecting_print_to_tqdm():
+    """
+    tqdm (progress bar) expects to have fairly tight control over console output.
+    so calls to `print()` will break the progress bar and make things look bad.
+    so, this context manager temporarily replaces the `print` implementation
+    with one that is compatible with tqdm.
+    via: https://stackoverflow.com/a/42424890/87207
+    """
+    old_print = print
+
+    def new_print(*args, **kwargs):
+
+        # If tqdm.tqdm.write raises error, use builtin print
+        try:
+            tqdm.tqdm.write(*args, **kwargs)
+        except:
+            old_print(*args, **kwargs)
+
+    try:
+        # Globaly replace print with new_print
+        inspect.builtins.print = new_print
+        yield
+    finally:
+        inspect.builtins.print = old_print
+
+
+@contextlib.contextmanager
+def timing(msg):
+    t0 = time.time()
+    yield
+    t1 = time.time()
+    logger.debug("perf: %s: %0.2fs", msg, t1 - t0)

--- a/scripts/idaplugin.py
+++ b/scripts/idaplugin.py
@@ -175,7 +175,7 @@ def main(argv=None):
     time0 = time.time()
 
     logger.info("identifying decoding functions...")
-    decoding_functions_candidates = floss.identify.find_decoding_functions(
+    decoding_functions_candidates = floss.identify.find_decoding_function_features(
         vw, selected_functions, count=10, disable_progress=True
     )
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import setuptools
 requirements = [
     "tabulate==0.8.9",
     "vivisect==1.0.5",
-    "viv-utils[flirt]==0.6.6",
+    "viv-utils[flirt]==0.6.7",
     "pydantic==1.8.2",
     "tqdm==4.62.3",
     "networkx==2.5.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import viv_utils
 
 import floss.main as floss_main
 import floss.stackstrings as stackstrings
-from floss.identify import find_decoding_functions
+from floss.identify import get_top_functions, find_decoding_function_features
 
 
 def extract_strings(vw):
@@ -17,11 +17,11 @@ def extract_strings(vw):
     """
     ret = []
     decoding_functions_candidates = identify_decoding_functions(vw)
-    for s in floss_main.decode_strings(vw, decoding_functions_candidates, 4):
+    for s in floss_main.decode_strings(vw, decoding_functions_candidates, 4, disable_progress=True):
         ret.append(s.string)
 
     selected_functions = floss_main.select_functions(vw, None)
-    for s in stackstrings.extract_stackstrings(vw, selected_functions, 4):
+    for s in stackstrings.extract_stackstrings(vw, selected_functions, 4, quiet=True):
         ret.append(s.string)
 
     return ret
@@ -29,8 +29,9 @@ def extract_strings(vw):
 
 def identify_decoding_functions(vw):
     selected_functions = floss_main.select_functions(vw, None)
-    decoding_functions_candidates, _ = find_decoding_functions(vw, list(selected_functions), count=10)
-    return list(map(lambda p: p[0], decoding_functions_candidates))
+    decoding_function_features, _ = find_decoding_function_features(vw, list(selected_functions), disable_progress=True)
+    top_functions = get_top_functions(decoding_function_features, 20)
+    return list(map(lambda p: p[0], top_functions))
 
 
 def pytest_collect_file(parent, path):


### PR DESCRIPTION
Adds tightstring extraction:
- identify functions with tight loops
- emulate similar to stack strings algorithm
- extracts tight string contexts after each tight loop executed
- filters out strings that were present before loop executed

There's still room for improvement but in preliminary tests the algorithm successfully extracts the desired strings.

This PR also adds a couple of random unrelated improvements (sorry for the mix up).