### PR TITLE
feat!: load and render from existing results doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flare-floss)
+[![Last release](https://img.shields.io/github/v/release/mandiant/flare-floss)](https://github.com/mandiant/flare-floss/releases)
 [![CI status](https://github.com/mandiant/flare-floss/actions/workflows/tests.yml/badge.svg)](https://github.com/mandiant/flare-floss/actions/workflows/tests.yml)
-[![build status](https://github.com/mandiant/flare-floss/actions/workflows/build.yml/badge.svg)](https://github.com/mandiant/flare-floss/actions/workflows/build.yml)
+[![Downloads](https://img.shields.io/github/downloads/mandiant/flare-floss/total)](https://github.com/mandiant/flare-floss/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 
 <img src="https://raw.githubusercontent.com/mandiant/flare-floss/master/resources/logo.png" width="350"/>
@@ -21,9 +22,9 @@ basic static analysis of unknown binaries.
 
 FLOSS extracts all the following string types:
 1. static strings: "regular" ASCII and UTF-16LE strings
-2. decoded strings: strings decoded in a function
-3. stack strings: strings constructed on the stack at run-time
-4. tight strings: special form of stack strings, decoded on the stack
+2. stack strings: strings constructed on the stack at run-time
+3. tight strings: special form of stack strings, decoded on the stack
+4. decoded strings: strings decoded in a function
 
 Please review the theory behind FLOSS [here](doc/theory.md). Our [blog post](https://www.mandiant.com/resources/automatically-extracting-obfuscated-strings) talks more about the motivation behind FLOSS and details how the tool works.
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-You can use FLOSS just like you'd use `strings.exe`:
+You can use FLOSS just like you'd use `strings.exe`
  to extract human-readable strings from binary data.
 The enhancement that FLOSS provides is that it statically
  analyzes executable files and decodes obfuscated strings.
@@ -24,10 +24,10 @@ To see all supported arguments run `floss -H`.
 
 ### Extract static, obfuscated, and stack strings (default mode)
 
-    floss.exe malware.bin
+    floss.exe malware.exe
 
 The default mode for FLOSS is to extract the following string types from an executable file:
-- static ASCII and UTF16LE strings
+- static ASCII and UTF-16LE strings
 - stack strings
 - tight strings
 - obfuscated strings
@@ -35,7 +35,7 @@ The default mode for FLOSS is to extract the following string types from an exec
 See the section on [Shellcode analysis](#shellcode) below on how to analyze raw binary files
 containing shellcode.
 
-By default, FLOSS uses a minimum string length of four.
+By default, FLOSS uses a minimum string length of four (4).
 
 
 ### Disable string type extraction (`--no {static,decoded,stack,tight}`)
@@ -47,14 +47,14 @@ This means you may be able to replace `strings.exe` with
  FLOSS in your analysis workflow. However, you may disable
  the extraction of static strings via the `--no static` switch.
 
-    floss.exe --no static -- malware.bin
+    floss.exe --no static -- malware.exe
 
 Since `--no` supports multiple arguments, end the command options with a double dash `--`.
 
 Analogous, you can disable the extraction of obfuscated strings, stackstrings or any combination.
 
-    floss.exe --no decoded -- malware.bin
-    floss.exe --no stack tight -- malware.bin
+    floss.exe --no decoded -- malware.exe
+    floss.exe --no stack tight -- malware.exe
 
 
 ### Enable string type extraction (`--only {static,decoded,stack,tight}`)
@@ -62,7 +62,7 @@ Analogous, you can disable the extraction of obfuscated strings, stackstrings or
 Sometimes it's easier to specify only the string type(s) you want to extract.
 Use the `--only` option for that.
 
-    floss.exe --only decoded -- malware.bin
+    floss.exe --only decoded -- malware.exe
 
 Please note that `--no` and `--only` cannot be used at the same time.
 
@@ -70,15 +70,22 @@ Please note that `--no` and `--only` cannot be used at the same time.
 
 Write FLOSS results to `stdout` structured in JSON to make it easy to ingest by a script.
 
-    floss.exe -j malware.bin
+    floss.exe -j malware.exe
 
 
 ### Write output to a file (`-o/--output`)
 
 Write FLOSS results to a provided output file path instead of `stdout`.
 
-    floss.exe -o malware_floss_results.txt malware.bin
-    floss.exe -j -o malware_floss_results.json malware.bin
+    floss.exe -o malware_floss_results.txt malware.exe
+    floss.exe -j -o malware_floss_results.json malware.exe
+
+
+### Load FLOSS results (`-l/--load`)
+
+Load a FLOSS results JSON document. This allows to explore FLOSS results without re-running the analysis.
+
+    floss.exe -l malware_floss_results.json
 
 
 ### Verbose results (`-v`)
@@ -86,7 +93,7 @@ Write FLOSS results to a provided output file path instead of `stdout`.
 Enable verbose results output, e.g. including function offsets and string encoding.
 This does not affect the JSON output.
 
-    floss.exe -v malware.bin
+    floss.exe -v malware.exe
 
 
 ### Quiet mode (`-q/--quiet`)
@@ -101,7 +108,7 @@ In quiet mode, each recovered string is printed on its
 The "type" of the string (static, decoded, stackstring, tightstring)
  is not included.
 
-     floss.exe -q malware.bin
+     floss.exe -q malware.exe
 
 
 ### Minimum string length (`-n/--minimum-length`)
@@ -115,7 +122,7 @@ Supplying a larger minimum length reduces the chances
  however, FLOSS may then pass over short legitimate
  human-readable strings
 
-    floss.exe -n 10 malware.bin
+    floss.exe -n 10 malware.exe
 
 
 ### Decoding function specification (`--functions`)
@@ -135,7 +142,7 @@ This can improve performance as FLOSS by perhaps one-third
   to always manually identify decoding routines).
 Specify functions by using their hex-encoded virtual address.
 
-    floss.exe --functions 0x401000 0x402000 malware.bin
+    floss.exe --functions 0x401000 0x402000 malware.exe
 
 
 ## <a name="shellcode"></a>Shellcode analysis options

--- a/floss/const.py
+++ b/floss/const.py
@@ -10,8 +10,6 @@ MAX_STRING_LENGTH = 2048
 # Decoded String (DS)
 # maximum number of instructions to emulate per function
 DS_MAX_INSN_COUNT = 20000
-# maximum number of address revisits per function when extracting contexts
-DS_MAX_ADDRESS_REVISITS_CTX_EXTRACTION = 1
 # maximum number of address revisits per function when emulating decoding functions
 DS_MAX_ADDRESS_REVISITS_EMULATION = 300
 # shortcut decoding of a function if only few strings are found

--- a/floss/identify.py
+++ b/floss/identify.py
@@ -62,7 +62,7 @@ def get_max_calls_to(vw, skip_thunks=True, skip_libs=True):
 
 
 def get_function_score_weighted(features):
-    return sum(feature.weighted_score() for feature in features) / sum(feature.weight for feature in features)
+    return round(sum(feature.weighted_score() for feature in features) / sum(feature.weight for feature in features), 3)
 
 
 def get_top_functions(candidate_functions, count=20) -> List[Dict[int, Dict]]:

--- a/floss/main.py
+++ b/floss/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # Copyright (C) 2017 Mandiant, Inc. All Rights Reserved.
-
 import os
 import sys
 import mmap
@@ -25,8 +24,16 @@ import floss.logging_
 import floss.render.json
 import floss.render.default
 from floss.const import MAX_FILE_SIZE, MIN_STRING_LENGTH, SUPPORTED_FILE_MAGIC
-from floss.utils import hex, get_imagebase, get_runtime_diff, get_vivisect_meta_info, set_vivisect_log_level
-from floss.results import Analysis, Metadata, ResultDocument
+from floss.utils import (
+    hex,
+    get_imagebase,
+    get_runtime_diff,
+    get_vivisect_meta_info,
+    is_string_type_enabled,
+    set_vivisect_log_level,
+)
+from floss.render import Verbosity
+from floss.results import Analysis, Metadata, ResultDocument, load
 from floss.strings import extract_ascii_unicode_strings
 from floss.version import __version__
 from floss.identify import (
@@ -52,9 +59,9 @@ logger = floss.logging_.getLogger("floss")
 
 class StringType(str, Enum):
     STATIC = "static"
-    DECODED = "decoded"
     STACK = "stack"
     TIGHT = "tight"
+    DECODED = "decoded"
 
 
 class WorkspaceLoadError(ValueError):
@@ -86,9 +93,9 @@ def make_parser(argv):
         f"  %(prog)s {__version__} - https://github.com/mandiant/flare-floss/\n\n"
         "FLOSS extracts all the following string types:\n"
         ' 1. static strings:  "regular" ASCII and UTF-16LE strings\n'
-        " 2. decoded strings: strings decoded in a function\n"
-        " 3. stack strings:   strings constructed on the stack at run-time\n"
-        " 4. tight strings:   special form of stack strings, decoded on the stack\n"
+        " 2. stack strings:   strings constructed on the stack at run-time\n"
+        " 3. tight strings:   special form of stack strings, decoded on the stack\n"
+        " 4. decoded strings: strings decoded in a function\n"
     )
     epilog = textwrap.dedent(
         """
@@ -177,6 +184,12 @@ def make_parser(argv):
         help="select sample format, %s" % format_help if show_all_options else argparse.SUPPRESS,
     )
     advanced_group.add_argument(
+        "-l",
+        "--load",
+        action="store_true",
+        help="load from existing FLOSS results document" if show_all_options else argparse.SUPPRESS,
+    )
+    advanced_group.add_argument(
         "--functions",
         type=lambda x: int(x, 0x10),
         default=None,
@@ -211,7 +224,7 @@ def make_parser(argv):
         "-v",
         "--verbose",
         action="count",
-        default=floss.render.default.Verbosity.DEFAULT,
+        default=Verbosity.DEFAULT,
         help="enable verbose results, e.g. including function offsets (does not affect JSON output)",
     )
     output_group.add_argument(
@@ -263,11 +276,9 @@ def set_log_config(debug, quiet):
 
     # configure viv-utils logging
     if debug == DebugLevel.DEFAULT:
-        logging.getLogger("Monitor").setLevel(logging.DEBUG)
-        logging.getLogger("EmulatorDriver").setLevel(logging.DEBUG)
+        logging.getLogger("viv_utils.emulator_drivers").setLevel(logging.DEBUG)
     elif debug <= DebugLevel.TRACE:
-        logging.getLogger("Monitor").setLevel(logging.ERROR)
-        logging.getLogger("EmulatorDriver").setLevel(logging.ERROR)
+        logging.getLogger("viv_utils.emulator_drivers").setLevel(logging.ERROR)
 
     # install the log message colorizer to the default handler.
     # because basicConfig is just above this,
@@ -433,13 +444,17 @@ def get_signatures(sigs_path):
     return paths
 
 
-def is_string_type_enabled(type_, disabled_types, enabled_types):
-    if disabled_types:
-        return type_ not in disabled_types
-    elif enabled_types:
-        return type_ in enabled_types
+def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool, outfile: Optional[str]):
+    if json_:
+        r = floss.render.json.render(results)
     else:
-        return True
+        r = floss.render.default.render(results, verbose, quiet)
+    if outfile:
+        logger.info("writing results to %s", outfile)
+        with open(outfile, "wb") as f:
+            f.write(r.encode("utf-8"))
+    else:
+        print(r)
 
 
 def main(argv=None) -> int:
@@ -488,16 +503,31 @@ def main(argv=None) -> int:
     args.sample.close()
 
     if args.functions:
-        # when analyzing specified functions do not show static strings
+        if is_string_type_enabled(StringType.STATIC, args.disabled_types, args.enabled_types):
+            logger.warning("analyzing specified functions, not showing static strings")
         args.disabled_types.append(StringType.STATIC)
 
     analysis = Analysis(
         enable_static_strings=is_string_type_enabled(StringType.STATIC, args.disabled_types, args.enabled_types),
         enable_stack_strings=is_string_type_enabled(StringType.STACK, args.disabled_types, args.enabled_types),
-        enable_decoded_strings=is_string_type_enabled(StringType.DECODED, args.disabled_types, args.enabled_types),
         enable_tight_strings=is_string_type_enabled(StringType.TIGHT, args.disabled_types, args.enabled_types),
+        enable_decoded_strings=is_string_type_enabled(StringType.DECODED, args.disabled_types, args.enabled_types),
     )
-    results = ResultDocument(metadata=Metadata(file_path=sample), analysis=analysis)
+
+    if args.load:
+        try:
+            results = load(sample, analysis, args.functions, args.min_length)
+        except floss.results.InvalidResultsFile as e:
+            logger.error("cannot load JSON results file: %s", e)
+            return -1
+        except floss.results.InvalidLoadConfig as e:
+            logger.error("%s", e)
+            return -1
+
+        write(results, args.json, args.verbose, args.quiet, args.outfile)
+        return 0
+
+    results = ResultDocument(metadata=Metadata(file_path=sample, min_length=args.min_length), analysis=analysis)
 
     time0 = time()
     interim = time0
@@ -632,17 +662,7 @@ def main(argv=None) -> int:
     results.metadata.runtime.total = get_runtime_diff(time0)
     logger.info("finished execution after %.2f seconds", results.metadata.runtime.total)
 
-    if args.json:
-        r = floss.render.json.render(results)
-    else:
-        r = floss.render.default.render(results, args.verbose, args.quiet)
-
-    if args.outfile:
-        logger.info("writing results to %s", args.outfile)
-        with open(args.outfile, "wb") as f:
-            f.write(r.encode("utf-8"))
-    else:
-        print(r)
+    write(results, args.json, args.verbose, args.quiet, args.outfile)
 
     return 0
 

--- a/floss/render/__init__.py
+++ b/floss/render/__init__.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Verbosity(int, Enum):
+    DEFAULT = 0
+    VERBOSE = 1

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -3,13 +3,13 @@
 import io
 import textwrap
 import collections
-from enum import Enum
 from typing import List, Tuple, Union
 
 import tabulate
 
+import floss.utils as util
 import floss.logging_
-from floss.utils import hex
+from floss.render import Verbosity
 from floss.results import AddressType, StackString, TightString, DecodedString, ResultDocument, StringEncoding
 from floss.render.sanitize import sanitize
 
@@ -21,11 +21,6 @@ DISABLED = "Disabled"
 tabulate.PRESERVE_WHITESPACE = True
 
 logger = floss.logging_.getLogger(__name__)
-
-
-class Verbosity(int, Enum):
-    DEFAULT = 0
-    VERBOSE = 1
 
 
 class StringIO(io.StringIO):
@@ -54,6 +49,7 @@ def render_meta(results: ResultDocument, ostream, verbose):
                 ("runtime", strtime(results.metadata.runtime.total)),
                 ("version", results.metadata.version),
                 ("imagebase", f"0x{results.metadata.imagebase:x}"),
+                ("min string length", f"{results.metadata.min_length}"),
             ]
         )
     rows.append(("extracted strings", ""))
@@ -165,7 +161,12 @@ def render_stackstrings(
             ostream.write(
                 tabulate.tabulate(
                     [
-                        (hex(s.function), hex(s.program_counter), hex(s.frame_offset), sanitize(s.string))
+                        (
+                            util.hex(s.function),
+                            util.hex(s.program_counter),
+                            util.hex(s.frame_offset),
+                            sanitize(s.string),
+                        )
                         for s in strings
                     ],
                     headers=("Function", "Function Offset", "Frame Offset", "String") if not disable_headers else (),

--- a/floss/results.py
+++ b/floss/results.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2021 Mandiant, Inc. All Rights Reserved.
 
+import json
 import datetime
 from enum import Enum
 from typing import Dict, List
@@ -13,12 +14,23 @@ from dataclasses import field
 #
 # really, you should just pretend we're using stock dataclasses.
 from pydantic.dataclasses import dataclass
+from pydantic.error_wrappers import ValidationError
 
+import floss.utils
 import floss.logging_
+from floss.render import Verbosity
 from floss.version import __version__
 from floss.render.sanitize import sanitize
 
 logger = floss.logging_.getLogger(__name__)
+
+
+class InvalidResultsFile(Exception):
+    pass
+
+
+class InvalidLoadConfig(Exception):
+    pass
 
 
 class StringEncoding(str, Enum):
@@ -143,11 +155,14 @@ class Functions:
 
 @dataclass
 class Analysis:
+    enable_static_strings: bool = True
     enable_stack_strings: bool = True
     enable_tight_strings: bool = True
     enable_decoded_strings: bool = True
-    enable_static_strings: bool = True
     functions: Functions = field(default_factory=Functions)
+
+
+STRING_TYPE_FIELDS = set([field for field in Analysis.__annotations__ if field.startswith("enable_")])
 
 
 @dataclass
@@ -155,6 +170,7 @@ class Metadata:
     file_path: str
     version: str = __version__
     imagebase: int = 0
+    min_length: int = 0
     runtime: Runtime = field(default_factory=Runtime)
 
 
@@ -179,7 +195,7 @@ class ResultDocument:
 
 def log_result(decoded_string, verbosity):
     string = sanitize(decoded_string.string)
-    if verbosity < floss.render.default.Verbosity.VERBOSE:
+    if verbosity < Verbosity.VERBOSE:
         logger.info("%s", string)
     else:
         if type(decoded_string) == DecodedString:
@@ -200,3 +216,67 @@ def log_result(decoded_string, verbosity):
             )
         else:
             ValueError("unknown decoded or extracted string type: %s", type(decoded_string))
+
+
+def load(sample: str, analysis: Analysis, functions: List[int], min_length: int) -> ResultDocument:
+    logger.debug("loading results document: %s", sample)
+    results = read(sample)
+    results.metadata.file_path = f"{sample}\n{results.metadata.file_path}"
+    ensure_string_types_exist(results, analysis)
+    if functions:
+        filter_functions(results, functions)
+    if min_length:
+        filter_string_len(results, min_length)
+        results.metadata.min_length = min_length
+    return results
+
+
+def read(sample: str) -> ResultDocument:
+    try:
+        with open(sample, "rb") as f:
+            results = json.loads(f.read().decode("utf-8"))
+    except (json.decoder.JSONDecodeError, UnicodeDecodeError) as e:
+        raise InvalidResultsFile(f"{e}")
+
+    try:
+        results = ResultDocument(**results)
+    except (TypeError, ValidationError) as e:
+        raise InvalidResultsFile(f"{sample} is not a valid FLOSS result document: {e}")
+
+    return results
+
+
+def ensure_string_types_exist(results: ResultDocument, wanted_analysis: Analysis) -> None:
+    for string_type in STRING_TYPE_FIELDS:
+        if getattr(wanted_analysis, string_type) and not getattr(results.analysis, string_type):
+            raise InvalidLoadConfig(f"{string_type} not in loaded data")
+        setattr(results.analysis, string_type, getattr(wanted_analysis, string_type))
+
+
+def filter_functions(results: ResultDocument, functions: List[int]) -> None:
+    filtered_scores = dict()
+    for fva in functions:
+        try:
+            filtered_scores[fva] = results.analysis.functions.decoding_function_scores[fva]
+        except KeyError:
+            raise InvalidLoadConfig(f"function {floss.utils.hex(fva)} not found in loaded data")
+    results.analysis.functions.decoding_function_scores = filtered_scores
+
+    results.strings.stack_strings = list(filter(lambda f: f.function in functions, results.strings.stack_strings))
+    results.strings.tight_strings = list(filter(lambda f: f.function in functions, results.strings.tight_strings))
+    results.strings.decoded_strings = list(
+        filter(lambda f: f.decoding_routine in functions, results.strings.decoded_strings)
+    )
+
+    results.analysis.functions.analyzed_stack_strings = len(results.strings.stack_strings)
+    results.analysis.functions.analyzed_tight_strings = len(results.strings.tight_strings)
+    results.analysis.functions.analyzed_decoded_strings = len(results.strings.decoded_strings)
+
+
+def filter_string_len(results: ResultDocument, min_length: int) -> None:
+    results.strings.static_strings = list(filter(lambda s: len(s.string) >= min_length, results.strings.static_strings))
+    results.strings.stack_strings = list(filter(lambda s: len(s.string) >= min_length, results.strings.stack_strings))
+    results.strings.tight_strings = list(filter(lambda s: len(s.string) >= min_length, results.strings.tight_strings))
+    results.strings.decoded_strings = list(
+        filter(lambda s: len(s.string) >= min_length, results.strings.decoded_strings)
+    )

--- a/floss/results.py
+++ b/floss/results.py
@@ -222,7 +222,7 @@ def load(sample: str, analysis: Analysis, functions: List[int], min_length: int)
     logger.debug("loading results document: %s", sample)
     results = read(sample)
     results.metadata.file_path = f"{sample}\n{results.metadata.file_path}"
-    ensure_string_types_exist(results, analysis)
+    check_set_string_types(results, analysis)
     if functions:
         filter_functions(results, functions)
     if min_length:
@@ -246,10 +246,10 @@ def read(sample: str) -> ResultDocument:
     return results
 
 
-def ensure_string_types_exist(results: ResultDocument, wanted_analysis: Analysis) -> None:
+def check_set_string_types(results: ResultDocument, wanted_analysis: Analysis) -> None:
     for string_type in STRING_TYPE_FIELDS:
         if getattr(wanted_analysis, string_type) and not getattr(results.analysis, string_type):
-            raise InvalidLoadConfig(f"{string_type} not in loaded data")
+            logger.warning(f"{string_type} not in loaded data, use --only/--no to enable/disable type(s)")
         setattr(results.analysis, string_type, getattr(wanted_analysis, string_type))
 
 

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -12,8 +12,8 @@ import viv_utils.emulator_drivers
 import floss.utils
 import floss.strings
 from floss.utils import getPointerSize, extract_strings
+from floss.render import Verbosity
 from floss.results import StackString
-from floss.render.default import Verbosity
 
 logger = floss.logging_.getLogger(__name__)
 MAX_STACK_SIZE = 0x10000

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -8,19 +8,19 @@ import viv_utils
 from vivisect import VivWorkspace
 
 import floss.utils
-import floss.render
 import floss.results
 import floss.strings
+import floss.logging_
 import floss.decoding_manager
 from floss.const import (
     DS_MAX_INSN_COUNT,
     DS_FUNCTION_CALLS_RARE,
     DS_FUNCTION_CALLS_OFTEN,
     DS_FUNCTION_MIN_DECODED_STRINGS,
-    DS_MAX_ADDRESS_REVISITS_CTX_EXTRACTION,
     DS_FUNCTION_SHORTCUT_THRESHOLD_VERY_OFTEN,
 )
 from floss.utils import is_all_zeros
+from floss.render import Verbosity
 from floss.results import AddressType, DecodedString
 from floss.decoding_manager import Delta
 from floss.function_argument_getter import extract_decoding_contexts
@@ -129,8 +129,7 @@ def decode_strings(
     functions: List[int],
     min_length: int,
     max_insn_count: int = DS_MAX_INSN_COUNT,
-    max_hits: int = DS_MAX_ADDRESS_REVISITS_CTX_EXTRACTION,
-    verbosity: int = floss.render.default.Verbosity.DEFAULT,
+    verbosity: int = Verbosity.DEFAULT,
     disable_progress: bool = False,
 ) -> List[DecodedString]:
     """
@@ -141,7 +140,6 @@ def decode_strings(
         functions: addresses of the candidate decoding routines
         min_length: minimum string length
         max_insn_count: max number of instructions to emulate per function
-        max_hits: max number of emulations per instruction
         verbosity: verbosity level
         disable_progress: no progress bar
     """

--- a/floss/tightstrings.py
+++ b/floss/tightstrings.py
@@ -12,9 +12,9 @@ import floss.utils
 import floss.features.features
 from floss.const import TS_MAX_INSN_COUNT, DS_MAX_ADDRESS_REVISITS_EMULATION
 from floss.utils import extract_strings
+from floss.render import Verbosity
 from floss.results import TightString
 from floss.stackstrings import CallContext, StackstringContextMonitor
-from floss.render.default import Verbosity
 
 logger = floss.logging_.getLogger(__name__)
 

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -369,3 +369,12 @@ def get_call_conv(api):
 
 def get_call_funcname(api):
     return api[3]
+
+
+def is_string_type_enabled(type_, disabled_types, enabled_types):
+    if disabled_types:
+        return type_ not in disabled_types
+    elif enabled_types:
+        return type_ in enabled_types
+    else:
+        return True


### PR DESCRIPTION
### Load FLOSS results (`-l/--load`)

Load a FLOSS results JSON document. This allows to explore FLOSS results without re-running the analysis.

    floss.exe -l malware_floss_results.json