### PR TITLE
Added text to subheadings that specifies the heading they come under.

### DIFF
--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -134,7 +134,7 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
         unicode_offset_len = len(f"{unicode_strings[-1].offset}")
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
-    render_heading("FLOSS ASCII STRINGS", len(ascii_strings), ostream, disable_headers)
+    render_heading("FLOSS STATIC STRINGS: ASCII", len(ascii_strings), ostream, disable_headers)
     for s in ascii_strings:
         if verbose == Verbosity.DEFAULT:
             ostream.writeln(s.string)
@@ -142,7 +142,7 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
             ostream.writeln(f"0x{s.offset:>0{offset_len}x} {s.string}")
     ostream.writeln("")
 
-    render_heading("FLOSS UTF-16LE STRINGS", len(unicode_strings), ostream, disable_headers)
+    render_heading("FLOSS STATIC STRINGS: UTF-16LE", len(unicode_strings), ostream, disable_headers)
     for s in unicode_strings:
         if verbose == Verbosity.DEFAULT:
             ostream.writeln(s.string)

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -206,7 +206,8 @@ def render_decoded_strings(decoded_strings: List[DecodedString], ostream, verbos
 
 def render_heading(heading, n, ostream, disable_headers):
     """
-    example:
+    example::
+
         ===========================
         ‖ FLOSS TIGHT STRINGS (0) ‖
         ===========================

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -134,7 +134,7 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
         unicode_offset_len = len(f"{unicode_strings[-1].offset}")
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
-    render_heading("FLOSS STATIC STRINGS: ASCII", len(ascii_strings), ostream, disable_headers)
+    render_sub_heading("FLOSS STATIC STRINGS: ASCII", len(ascii_strings), ostream, disable_headers)
     for s in ascii_strings:
         if verbose == Verbosity.DEFAULT:
             ostream.writeln(s.string)
@@ -142,7 +142,7 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
             ostream.writeln(f"0x{s.offset:>0{offset_len}x} {s.string}")
     ostream.writeln("")
 
-    render_heading("FLOSS STATIC STRINGS: UTF-16LE", len(unicode_strings), ostream, disable_headers)
+    render_sub_heading("FLOSS STATIC STRINGS: UTF-16LE", len(unicode_strings), ostream, disable_headers)
     for s in unicode_strings:
         if verbose == Verbosity.DEFAULT:
             ostream.writeln(s.string)
@@ -206,11 +206,25 @@ def render_decoded_strings(decoded_strings: List[DecodedString], ostream, verbos
 
 def render_heading(heading, n, ostream, disable_headers):
     """
+        example:
+        ===========================
+        ‖ FLOSS TIGHT STRINGS (0) ‖
+        ===========================
+    """
+    if disable_headers:
+        return
+    heading = f"‖ {heading} ({n}) ‖"
+    ostream.write(tabulate.tabulate([[heading]], tablefmt="rst"))
+    ostream.write("\n")
+
+
+def render_sub_heading(heading, n, ostream, disable_headers):
+    """
     example::
 
-        +-----------------------------+
-        | FLOSS STATIC STRINGS (1337) |
-        +-----------------------------+
+        +-----------------------------------+
+        | FLOSS STATIC STRINGS: ASCII (862) |
+        +-----------------------------------+
     """
     if disable_headers:
         return

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -206,7 +206,7 @@ def render_decoded_strings(decoded_strings: List[DecodedString], ostream, verbos
 
 def render_heading(heading, n, ostream, disable_headers):
     """
-        example:
+    example:
         ===========================
         ‖ FLOSS TIGHT STRINGS (0) ‖
         ===========================


### PR DESCRIPTION

Currently the subheadings for static strings look like:
```
-------------------------------
| FLOSS STATIC STRINGS (8188) |
-------------------------------
------------------------------
| FLOSS ASCII STRINGS (7298) |
------------------------------
!This program cannot be run in DOS mode.
```

Changed them to:

```
-------------------------------
| FLOSS STATIC STRINGS (3119) |
-------------------------------
--------------------------------------
| FLOSS STATIC STRINGS: ASCII (3119) |
--------------------------------------
...
--------------------------------------
| FLOSS STATIC STRINGS: UTF-16LE (0) |
--------------------------------------
```

I wonder though, could we also use another table format for the subheadings to make them stand out from the headings? I tried looking around in tabulate but didn't feel like any format would appear "lighter" than the ones currently in use for headings.

resolves #621 