### PR TITLE
sigpaths parameter datatype

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -361,7 +361,7 @@ class Architecture(str, Enum):
 def load_vw(
     sample_path: str,
     format: str,
-    sigpaths: str,
+    sigpaths: list,
     should_save_workspace: bool = False,
 ) -> VivWorkspace:
     if format not in ("sc32", "sc64"):

--- a/floss/main.py
+++ b/floss/main.py
@@ -361,7 +361,7 @@ class Architecture(str, Enum):
 def load_vw(
     sample_path: str,
     format: str,
-    sigpaths: list,
+    sigpaths: List[str],
     should_save_workspace: bool = False,
 ) -> VivWorkspace:
     if format not in ("sc32", "sc64"):


### PR DESCRIPTION
The sigpaths parameter in the load_vw function expects a string, but is passed a list.
Changed:
```
def load_vw(
    sample_path: str,
    format: str,
    sigpaths: str,
    should_save_workspace: bool = False,
) -> VivWorkspace:
```
to:
```
def load_vw(
    sample_path: str,
    format: str,
    sigpaths: list,
    should_save_workspace: bool = False,
) -> VivWorkspace:
```
The paths are loaded by the get_signatures function, which returns a list.