### PR TITLE
cleaning is_workspace_file function

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -333,9 +333,7 @@ def is_workspace_file(sample_file_path):
     :param sample_file_path:
     :return: True if file extension is .viv, False otherwise
     """
-    if os.path.splitext(sample_file_path)[1] == ".viv":
-        return True
-    return False
+    return os.path.splitext(sample_file_path)[1] == ".viv"
 
 
 def is_supported_file_type(sample_file_path):

--- a/floss/main.py
+++ b/floss/main.py
@@ -327,15 +327,6 @@ def select_functions(vw, asked_functions: Optional[List[int]]) -> Set[int]:
     return asked_functions_
 
 
-def is_workspace_file(sample_file_path):
-    """
-    Return if input file is a vivisect workspace, based on file extension
-    :param sample_file_path:
-    :return: True if file extension is .viv, False otherwise
-    """
-    return os.path.splitext(sample_file_path)[1] == ".viv"
-
-
 def is_supported_file_type(sample_file_path):
     """
     Return if FLOSS supports the input file type, based on header bytes


### PR DESCRIPTION
I am still not sure about if this function is useful, there seem to be no usages in the code... Is it useful when FLOSS is used as a module? I have cleaned it for now, but should I remove it completely?

The function:
```
def is_workspace_file(sample_file_path):
    """
    Return if input file is a vivisect workspace, based on file extension
    :param sample_file_path:
    :return: True if file extension is .viv, False otherwise
    """
    if os.path.splitext(sample_file_path)[1] == ".viv":
        return True
    return False
```
Original:
```
if os.path.splitext(sample_file_path)[1] == ".viv":
     return True
return False
```
Changed:
```
return os.path.splitext(sample_file_path)[1] == ".viv"
```