### PR TITLE
Added colors to differentiate results output #623

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -266,10 +266,8 @@ def make_parser(argv):
 
 
 def set_color_config(color):
-    import codecs
-
-    codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp65001" else None)
-    codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp1252" else None)
+    import sys
+    sys.stdout.reconfigure(encoding='utf-8')
 
     if color == "always":
         colorama.init(strip=False)

--- a/floss/main.py
+++ b/floss/main.py
@@ -269,6 +269,7 @@ def set_color_config(color):
     import codecs
 
     codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp65001" else None)
+    codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp1252" else None)
 
     if color == "always":
         colorama.init(strip=False)

--- a/floss/main.py
+++ b/floss/main.py
@@ -266,8 +266,7 @@ def make_parser(argv):
 
 
 def set_color_config(color):
-    import sys
-    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stdout.reconfigure(encoding="utf-8")
 
     if color == "always":
         colorama.init(strip=False)

--- a/floss/main.py
+++ b/floss/main.py
@@ -266,7 +266,7 @@ def make_parser(argv):
 
 
 def set_color_config(color):
-    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stdout.reconfigure(encoding="utf-8")
     colorama.just_fix_windows_console()
 
     if color == "always":

--- a/floss/main.py
+++ b/floss/main.py
@@ -266,6 +266,10 @@ def make_parser(argv):
 
 
 def set_color_config(color):
+    import codecs
+
+    codecs.register(lambda name: codecs.lookup("utf-8") if name == "cp65001" else None)
+
     if color == "always":
         colorama.init(strip=False)
     elif color == "auto":

--- a/floss/main.py
+++ b/floss/main.py
@@ -10,7 +10,6 @@ import textwrap
 import contextlib
 from enum import Enum
 from time import time
-import sys
 from typing import Set, List, Optional
 
 import halo

--- a/floss/main.py
+++ b/floss/main.py
@@ -8,12 +8,12 @@ import logging
 import argparse
 import textwrap
 import contextlib
-import colorama
 from enum import Enum
 from time import time
 from typing import Set, List, Optional
 
 import halo
+import colorama
 import viv_utils
 import viv_utils.flirt
 from vivisect import VivWorkspace
@@ -265,8 +265,7 @@ def make_parser(argv):
     return parser
 
 
-def set_log_config(debug, quiet, color):
-
+def set_color_config(color):
     if color == "always":
         colorama.init(strip=False)
     elif color == "auto":
@@ -279,7 +278,9 @@ def set_log_config(debug, quiet, color):
         colorama.init(strip=True)
     else:
         raise RuntimeError("unexpected --color value: " + color)
-    
+
+
+def set_log_config(debug, quiet):
     if quiet:
         log_level = logging.WARNING
     elif debug >= DebugLevel.TRACE:
@@ -493,7 +494,8 @@ def main(argv=None) -> int:
         print(e)
         return -1
 
-    set_log_config(args.debug, args.quiet, args.color)
+    set_log_config(args.debug, args.quiet)
+    set_color_config(args.color)
 
     # Since Python 3.8 cp65001 is an alias to utf_8, but not for Python < 3.8
     # TODO: remove this code when only supporting Python 3.8+

--- a/floss/main.py
+++ b/floss/main.py
@@ -10,6 +10,7 @@ import textwrap
 import contextlib
 from enum import Enum
 from time import time
+import sys
 from typing import Set, List, Optional
 
 import halo
@@ -266,6 +267,7 @@ def make_parser(argv):
 
 
 def set_color_config(color):
+    sys.stdout.reconfigure(encoding='utf-8')
     colorama.just_fix_windows_console()
 
     if color == "always":

--- a/floss/main.py
+++ b/floss/main.py
@@ -266,7 +266,7 @@ def make_parser(argv):
 
 
 def set_color_config(color):
-    sys.stdout.reconfigure(encoding="utf-8")
+    colorama.just_fix_windows_console()
 
     if color == "always":
         colorama.init(strip=False)

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -30,6 +30,16 @@ class StringIO(io.StringIO):
         self.write("\n")
 
 
+def heading_style(str):
+    colored_string = colored(str, "blue", attrs=["bold"])
+    return colored_string
+
+
+def string_style(str):
+    colored_string = colored(str, "green", attrs=["bold"])
+    return colored_string
+
+
 def width(s: str, character_count: int) -> str:
     """pad the given string to at least `character_count`"""
     if len(s) < character_count:
@@ -135,22 +145,24 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
         unicode_offset_len = len(f"{unicode_strings[-1].offset}")
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
-    render_sub_heading("FLOSS STATIC STRINGS: " + colored("ASCII", "blue", attrs=['bold']), len(ascii_strings), ostream, disable_headers)
+    render_sub_heading("FLOSS STATIC STRINGS: " + heading_style("ASCII"), len(ascii_strings), ostream, disable_headers)
     for s in ascii_strings:
-        str_ = colored(s.string, "green", attrs=['bold'])
+        colored_string = string_style(s.string)
         if verbose == Verbosity.DEFAULT:
-            ostream.writeln(str_)
+            ostream.writeln(colored_string)
         else:
-            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {str_}")
+            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {colored_string}")
     ostream.writeln("")
 
-    render_sub_heading("FLOSS STATIC STRINGS: " + colored("UTF-16LE", "blue", attrs=['bold']), len(unicode_strings), ostream, disable_headers)
+    render_sub_heading(
+        "FLOSS STATIC STRINGS: " + heading_style("UTF-16LE"), len(unicode_strings), ostream, disable_headers
+    )
     for s in unicode_strings:
-        str_ = colored(s.string, "green", attrs=['bold'])
+        colored_string = string_style(s.string)
         if verbose == Verbosity.DEFAULT:
-            ostream.writeln(str_)
+            ostream.writeln(colored_string)
         else:
-            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {str_}")
+            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {colored_string}")
 
 
 def render_stackstrings(
@@ -168,7 +180,7 @@ def render_stackstrings(
                             util.hex(s.function),
                             util.hex(s.program_counter),
                             util.hex(s.frame_offset),
-                            colored(sanitize(s.string), "green", attrs=['bold']),
+                            string_style(sanitize(s.string)),
                         )
                         for s in strings
                     ],
@@ -191,14 +203,14 @@ def render_decoded_strings(decoded_strings: List[DecodedString], ostream, verbos
             strings_by_functions[ds.decoding_routine].append(ds)
 
         for fva, data in strings_by_functions.items():
-            render_sub_heading(" FUNCTION at "+colored(f"0x{fva:x}", "blue", attrs=['bold']), len(data), ostream, disable_headers)
+            render_sub_heading(" FUNCTION at " + heading_style(f"0x{fva:x}"), len(data), ostream, disable_headers)
             rows = []
             for ds in data:
                 if ds.address_type in (AddressType.HEAP, AddressType.STACK):
                     offset_string = f"({ds.address_type})"
                 else:
                     offset_string = hex(ds.address or 0)
-                rows.append((offset_string, hex(ds.decoded_at), colored(sanitize(ds.string), "green", attrs=['bold'])))
+                rows.append((offset_string, hex(ds.decoded_at), string_style(ds.string)))
 
             if rows:
                 ostream.write(
@@ -219,7 +231,7 @@ def render_heading(heading, n, ostream, disable_headers):
         return
     heading = f"‖ {heading} ({n}) ‖"
     table = tabulate.tabulate([[heading]], tablefmt="rst")
-    ostream.write(colored(table, "blue", attrs=['bold']))
+    ostream.write(heading_style(table))
     ostream.write("\n")
 
 
@@ -243,7 +255,7 @@ def render(results, verbose, disable_headers):
 
     if not disable_headers:
         ostream.writeln("")
-        colored_str = colored(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n", "blue", attrs=['bold'])
+        colored_str = heading_style(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
         ostream.write(colored_str)
         render_meta(results, ostream, verbose)
         ostream.writeln("")

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -6,6 +6,7 @@ import collections
 from typing import List, Tuple, Union
 
 import tabulate
+from termcolor import colored
 
 import floss.utils as util
 import floss.logging_
@@ -134,20 +135,22 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
         unicode_offset_len = len(f"{unicode_strings[-1].offset}")
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
-    render_sub_heading("FLOSS STATIC STRINGS: ASCII", len(ascii_strings), ostream, disable_headers)
+    render_sub_heading("FLOSS STATIC STRINGS: " + colored("ASCII", "blue", attrs=['bold']), len(ascii_strings), ostream, disable_headers)
     for s in ascii_strings:
+        str_ = colored(s.string, "green", attrs=['bold'])
         if verbose == Verbosity.DEFAULT:
-            ostream.writeln(s.string)
+            ostream.writeln(str_)
         else:
-            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {s.string}")
+            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {str_}")
     ostream.writeln("")
 
-    render_sub_heading("FLOSS STATIC STRINGS: UTF-16LE", len(unicode_strings), ostream, disable_headers)
+    render_sub_heading("FLOSS STATIC STRINGS: " + colored("UTF-16LE", "blue", attrs=['bold']), len(unicode_strings), ostream, disable_headers)
     for s in unicode_strings:
+        str_ = colored(s.string, "green", attrs=['bold'])
         if verbose == Verbosity.DEFAULT:
-            ostream.writeln(s.string)
+            ostream.writeln(str_)
         else:
-            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {s.string}")
+            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {str_}")
 
 
 def render_stackstrings(
@@ -165,7 +168,7 @@ def render_stackstrings(
                             util.hex(s.function),
                             util.hex(s.program_counter),
                             util.hex(s.frame_offset),
-                            sanitize(s.string),
+                            colored(sanitize(s.string), "green", attrs=['bold']),
                         )
                         for s in strings
                     ],
@@ -188,14 +191,14 @@ def render_decoded_strings(decoded_strings: List[DecodedString], ostream, verbos
             strings_by_functions[ds.decoding_routine].append(ds)
 
         for fva, data in strings_by_functions.items():
-            render_heading(f" FUNCTION at 0x{fva:x}", len(data), ostream, disable_headers)
+            render_sub_heading(" FUNCTION at "+colored(f"0x{fva:x}", "blue", attrs=['bold']), len(data), ostream, disable_headers)
             rows = []
             for ds in data:
                 if ds.address_type in (AddressType.HEAP, AddressType.STACK):
                     offset_string = f"({ds.address_type})"
                 else:
                     offset_string = hex(ds.address or 0)
-                rows.append((offset_string, hex(ds.decoded_at), sanitize(ds.string)))
+                rows.append((offset_string, hex(ds.decoded_at), colored(sanitize(ds.string), "green", attrs=['bold'])))
 
             if rows:
                 ostream.write(
@@ -215,7 +218,8 @@ def render_heading(heading, n, ostream, disable_headers):
     if disable_headers:
         return
     heading = f"‖ {heading} ({n}) ‖"
-    ostream.write(tabulate.tabulate([[heading]], tablefmt="rst"))
+    table = tabulate.tabulate([[heading]], tablefmt="rst")
+    ostream.write(colored(table, "blue", attrs=['bold']))
     ostream.write("\n")
 
 
@@ -239,7 +243,8 @@ def render(results, verbose, disable_headers):
 
     if not disable_headers:
         ostream.writeln("")
-        ostream.write(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
+        colored_str = colored(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n", "blue", attrs=['bold'])
+        ostream.write(colored_str)
         render_meta(results, ostream, verbose)
         ostream.writeln("")
 

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@ requirements = [
     "tqdm==4.65.0",
     "networkx==2.5.1",
     "halo==0.0.31",
-    "termcolor==2.2.0",
-    "colorama==0.4.4",
-    "types-colorama==0.4.15.8",
 ]
 
 # this sets __version__
@@ -69,6 +66,9 @@ setuptools.setup(
             # type stubs for mypy
             "types-PyYAML==6.0.10",
             "types-tabulate==0.9.0.1",
+            "termcolor==2.2.0",
+            "colorama==0.4.4",
+            "types-colorama==0.4.15.8",
         ],
         "build": [
             "pyinstaller==5.8.0",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     "halo==0.0.31",
     "termcolor==2.2.0",
     "colorama==0.4.4",
+    "types-colorama==0.4.15.8",
 ]
 
 # this sets __version__

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ requirements = [
     "tqdm==4.65.0",
     "networkx==2.5.1",
     "halo==0.0.31",
+    "termcolor==2.2.0",
+    "colorama==0.4.6",
 ]
 
 # this sets __version__
@@ -66,8 +68,6 @@ setuptools.setup(
             # type stubs for mypy
             "types-PyYAML==6.0.10",
             "types-tabulate==0.9.0.1",
-            "termcolor==2.2.0",
-            "colorama==0.4.4",
             "types-colorama==0.4.15.8",
         ],
         "build": [

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ requirements = [
     "tqdm==4.65.0",
     "networkx==2.5.1",
     "halo==0.0.31",
+    "termcolor==2.2.0",
+    "colorama==0.4.4",
 ]
 
 # this sets __version__


### PR DESCRIPTION
This pull request adds color to the output of the program to make it easier to read and navigate. Specifically, it adds color to important elements such as headings and strings. The 'colorama' and 'termcolor' library has been used to achieve this.

Changes Made:

- Added the 'colorama' and 'termcolor' libraries as a dependency in setup.py
- Modified the code to use these libraries to add color to the output
- Added a command line argument --color to enable/disable color output
- Added support for the NO_COLOR environment variable as per the convention described in https://no-color.org/ via 'termcolor' library
- Works in both light and dark backgrounds

Testing:
  Tested the code on ubuntu 22.04 and windows 11

Screenshots:
<p float=left>
<img width="50%" src="https://user-images.githubusercontent.com/94680887/224026692-d647d264-5ec8-4497-9323-77a0206b966e.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/224026717-633f7cb4-edce-4a95-a8a1-427c6923cdb0.png">
</p>
<p float=left>
<img width="50%" src="https://user-images.githubusercontent.com/94680887/224026734-b8896598-ce29-4491-bc91-0f6fa021f117.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/224026742-84f60fb9-33b7-4402-8f88-0233e03cb09d.png">
</p>

Please review the code changes and provide feedback on the implementation. Let me know if there are any suggestions or concerns. Thank you!