### PR TITLE
Replace termcolor with rich #623

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -448,7 +448,6 @@ def get_signatures(sigs_path):
 
 
 def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool, outfile: Optional[str], color):
-    sys.stdout.reconfigure(encoding="utf-8")
     if json_:
         r = floss.render.json.render(results)
     else:

--- a/floss/main.py
+++ b/floss/main.py
@@ -448,6 +448,7 @@ def get_signatures(sigs_path):
 
 
 def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool, outfile: Optional[str], color):
+    sys.stdout.reconfigure(encoding="utf-8")
     if json_:
         r = floss.render.json.render(results)
     else:

--- a/floss/main.py
+++ b/floss/main.py
@@ -235,12 +235,6 @@ def make_parser(argv):
         default=Verbosity.DEFAULT,
         help="enable verbose results, e.g. including function offsets (does not affect JSON output)",
     )
-    output_group.add_argument(
-        "-o",
-        "--outfile",
-        type=str,
-        help="write results to output file, instead of default STDOUT",
-    )
 
     logging_group = parser.add_argument_group("logging arguments")
     logging_group.add_argument(
@@ -447,17 +441,13 @@ def get_signatures(sigs_path):
     return paths
 
 
-def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool, outfile: Optional[str], color):
+def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool, color):
     if json_:
         r = floss.render.json.render(results)
     else:
         r = floss.render.default.render(results, verbose, quiet, color)
-    if outfile:
-        logger.info("writing results to %s", outfile)
-        with open(outfile, "wb") as f:
-            f.write(r.encode("utf-8"))
-    else:
-        print(r)
+
+    print(r)
 
 
 def main(argv=None) -> int:
@@ -527,7 +517,7 @@ def main(argv=None) -> int:
             logger.error("%s", e)
             return -1
 
-        write(results, args.json, args.verbose, args.quiet, args.outfile, args.color)
+        write(results, args.json, args.verbose, args.quiet, args.color)
         return 0
 
     results = ResultDocument(metadata=Metadata(file_path=sample, min_length=args.min_length), analysis=analysis)
@@ -674,7 +664,7 @@ def main(argv=None) -> int:
     results.metadata.runtime.total = get_runtime_diff(time0)
     logger.info("finished execution after %.2f seconds", results.metadata.runtime.total)
 
-    write(results, args.json, args.verbose, args.quiet, args.outfile, args.color)
+    write(results, args.json, args.verbose, args.quiet, args.color)
 
     return 0
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -441,15 +441,6 @@ def get_signatures(sigs_path):
     return paths
 
 
-def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool, color):
-    if json_:
-        r = floss.render.json.render(results)
-    else:
-        r = floss.render.default.render(results, verbose, quiet, color)
-
-    print(r)
-
-
 def main(argv=None) -> int:
     """
     arguments:
@@ -517,8 +508,12 @@ def main(argv=None) -> int:
             logger.error("%s", e)
             return -1
 
-        write(results, args.json, args.verbose, args.quiet, args.color)
-        return 0
+        if args.json:
+            r = floss.render.json.render(results)
+        else:
+            r = floss.render.default.render(results, args.verbose, args.quiet, args.color)
+
+        print(r)
 
     results = ResultDocument(metadata=Metadata(file_path=sample, min_length=args.min_length), analysis=analysis)
 
@@ -664,7 +659,12 @@ def main(argv=None) -> int:
     results.metadata.runtime.total = get_runtime_diff(time0)
     logger.info("finished execution after %.2f seconds", results.metadata.runtime.total)
 
-    write(results, args.json, args.verbose, args.quiet, args.color)
+    if args.json:
+            r = floss.render.json.render(results)
+    else:
+        r = floss.render.default.render(results, args.verbose, args.quiet, args.color)
+
+    print(r)
 
     return 0
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -11,13 +11,13 @@ import contextlib
 from enum import Enum
 from time import time
 from typing import Set, List, Optional
-from rich.console import Console
 
 import halo
 import colorama
 import viv_utils
 import viv_utils.flirt
 from vivisect import VivWorkspace
+from rich.console import Console
 
 import floss.utils
 import floss.results
@@ -57,6 +57,7 @@ EXTENSIONS_SHELLCODE_32 = ("sc32", "raw32")
 EXTENSIONS_SHELLCODE_64 = ("sc64", "raw64")
 
 logger = floss.logging_.getLogger("floss")
+
 
 class StringType(str, Enum):
     STATIC = "static"
@@ -268,18 +269,17 @@ def make_parser(argv):
 def set_color_config(color):
     sys.stdout.reconfigure(encoding="utf-8")
     colorama.just_fix_windows_console()
-    
+
     if color == "always":
-        console = Console(color_system='standard', highlight=False)
+        console = Console(color_system="standard", highlight=False)
     elif color == "auto":
-        console = Console(color_system='auto', highlight=False)
+        console = Console(color_system="auto", highlight=False)
     elif color == "never":
         console = Console(color_system=None, highlight=False)
     else:
-         raise RuntimeError("unexpected --color value: " + color)
+        raise RuntimeError("unexpected --color value: " + color)
 
     return console
-
 
 
 def set_log_config(debug, quiet):
@@ -477,7 +477,6 @@ def write(results: ResultDocument, json_: bool, verbose: Verbosity, quiet: bool,
     else:
         # print(r)
         console.print(r)
-        
 
 
 def main(argv=None) -> int:

--- a/floss/main.py
+++ b/floss/main.py
@@ -660,7 +660,7 @@ def main(argv=None) -> int:
     logger.info("finished execution after %.2f seconds", results.metadata.runtime.total)
 
     if args.json:
-            r = floss.render.json.render(results)
+        r = floss.render.json.render(results)
     else:
         r = floss.render.default.render(results, args.verbose, args.quiet, args.color)
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -515,6 +515,8 @@ def main(argv=None) -> int:
 
         print(r)
 
+        return 0
+
     results = ResultDocument(metadata=Metadata(file_path=sample, min_length=args.min_length), analysis=analysis)
 
     time0 = time()

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -8,6 +8,7 @@ from typing import List, Tuple, Union
 
 from rich import box
 from rich.table import Table
+from rich.markup import escape
 from rich.console import Console
 
 import floss.utils as util
@@ -204,9 +205,9 @@ def render_decoded_strings(decoded_strings: List[DecodedString], console, verbos
             rows = []
             for ds in data:
                 if ds.address_type == AddressType.STACK:
-                    offset_string = "\[stack]"
+                    offset_string = escape("[stack]")
                 elif ds.address_type == AddressType.HEAP:
-                    offset_string = "\[heap]"
+                    offset_string = escape("[heap]")
                 else:
                     offset_string = hex(ds.address or 0)
                 rows.append((offset_string, hex(ds.decoded_at), string_style(ds.string)))

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -204,9 +204,9 @@ def render_decoded_strings(decoded_strings: List[DecodedString], console, verbos
             rows = []
             for ds in data:
                 if ds.address_type == AddressType.STACK:
-                    offset_string = "\[Stack]"
+                    offset_string = "\[stack]"
                 elif ds.address_type == AddressType.HEAP:
-                    offset_string = "\[Heap]"
+                    offset_string = "\[heap]"
                 else:
                     offset_string = hex(ds.address or 0)
                 rows.append((offset_string, hex(ds.decoded_at), string_style(ds.string)))

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 Mandiant, Inc. All Rights Reserved.
 
 import io
+import sys
 import textwrap
 import collections
 from typing import List, Tuple, Union
@@ -272,6 +273,7 @@ def get_color(color):
 
 
 def render(results, verbose, disable_headers, color):
+    sys.stdout.reconfigure(encoding="utf-8")
     console = Console(file=io.StringIO(), color_system=get_color(color), highlight=False)
 
     if not disable_headers:

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -6,10 +6,10 @@ import collections
 from typing import List, Tuple, Union
 
 import tabulate
-from termcolor import colored
-from rich.console import Console
-from rich.table import Table
 from rich import box
+from termcolor import colored
+from rich.table import Table
+from rich.console import Console
 
 import floss.utils as util
 import floss.logging_
@@ -70,13 +70,12 @@ def render_meta(results: ResultDocument, console, verbose):
     rows.extend(render_string_type_rows(results))
     if verbose > Verbosity.DEFAULT:
         rows.extend(render_function_analysis_rows(results))
-    
+
     table = Table(box=box.ASCII2, show_header=False)
     for row in rows:
         table.add_row(str(row[0]), str(row[1]))
 
     console.print(table)
-
 
 
 def render_string_type_rows(results: ResultDocument) -> List[Tuple[str, str]]:
@@ -177,17 +176,17 @@ def render_stackstrings(
             console.print(sanitize(s.string))
     else:
         if strings:
-            
-            table = Table("Function", "Function Offset", "Frame Offset", "String", show_header=not(disable_headers))
+            table = Table("Function", "Function Offset", "Frame Offset", "String", show_header=not (disable_headers))
             for s in strings:
-                table.add_row(util.hex(s.function),
-                            util.hex(s.program_counter),
-                            util.hex(s.frame_offset),
-                            string_style(sanitize(s.string)))
-                            
+                table.add_row(
+                    util.hex(s.function),
+                    util.hex(s.program_counter),
+                    util.hex(s.frame_offset),
+                    string_style(sanitize(s.string)),
+                )
+
             console.print(table)
             console.print("\n")
-            
 
 
 def render_decoded_strings(decoded_strings: List[DecodedString], console, verbose, disable_headers):
@@ -215,12 +214,13 @@ def render_decoded_strings(decoded_strings: List[DecodedString], console, verbos
                 rows.append((offset_string, hex(ds.decoded_at), string_style(ds.string)))
 
             if rows:
-                table = Table("Offset", "Called At", "String", show_header=not(disable_headers), box=box.ASCII2, show_edge=False)
+                table = Table(
+                    "Offset", "Called At", "String", show_header=not (disable_headers), box=box.ASCII2, show_edge=False
+                )
                 for row in rows:
                     table.add_row(row[0], row[1], row[2])
                 console.print(table)
-                console.print('\n')
-
+                console.print("\n")
 
 
 def render_heading(heading, n, console, verbose, disable_headers):
@@ -262,35 +262,34 @@ def render_sub_heading(heading, n, console, disable_headers):
 
 
 def render(results, verbose, disable_headers):
-    console = Console(file=io.StringIO(), color_system='256', highlight=False)
+    console = Console(file=io.StringIO(), color_system="256", highlight=False)
 
     if not disable_headers:
-        console.print('\n')
+        console.print("\n")
         if verbose == Verbosity.DEFAULT:
             console.print(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
         else:
             colored_str = heading_style(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
             console.print(colored_str)
         render_meta(results, console, verbose)
-        console.print('\n')
+        console.print("\n")
 
     if results.analysis.enable_static_strings:
         render_staticstrings(results.strings.static_strings, console, verbose, disable_headers)
-        console.print('\n')
+        console.print("\n")
 
     if results.analysis.enable_stack_strings:
         render_heading("FLOSS STACK STRINGS", len(results.strings.stack_strings), console, verbose, disable_headers)
         render_stackstrings(results.strings.stack_strings, console, verbose, disable_headers)
-        console.print('\n')
+        console.print("\n")
 
     if results.analysis.enable_tight_strings:
         render_heading("FLOSS TIGHT STRINGS", len(results.strings.tight_strings), console, verbose, disable_headers)
         render_stackstrings(results.strings.tight_strings, console, verbose, disable_headers)
-        console.print('\n')
+        console.print("\n")
 
     if results.analysis.enable_decoded_strings:
         render_heading("FLOSS DECODED STRINGS", len(results.strings.decoded_strings), console, verbose, disable_headers)
         render_decoded_strings(results.strings.decoded_strings, console, verbose, disable_headers)
 
     return console.file.getvalue()
-

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -7,6 +7,9 @@ from typing import List, Tuple, Union
 
 import tabulate
 from termcolor import colored
+from rich.console import Console
+from rich.table import Table
+from rich import box
 
 import floss.utils as util
 import floss.logging_
@@ -31,12 +34,12 @@ class StringIO(io.StringIO):
 
 
 def heading_style(str):
-    colored_string = colored(str, "cyan")
+    colored_string = "[cyan]" + str + "[/cyan]"
     return colored_string
 
 
 def string_style(str):
-    colored_string = colored(str, "green")
+    colored_string = "[green]" + str + " [/green]"
     return colored_string
 
 
@@ -48,7 +51,7 @@ def width(s: str, character_count: int) -> str:
         return s
 
 
-def render_meta(results: ResultDocument, ostream, verbose):
+def render_meta(results: ResultDocument, console, verbose):
     rows: List[Tuple[str, str]] = list()
     if verbose == Verbosity.DEFAULT:
         rows.append((width("file path", MIN_WIDTH_LEFT_COL), width(results.metadata.file_path, MIN_WIDTH_RIGHT_COL)))
@@ -67,9 +70,13 @@ def render_meta(results: ResultDocument, ostream, verbose):
     rows.extend(render_string_type_rows(results))
     if verbose > Verbosity.DEFAULT:
         rows.extend(render_function_analysis_rows(results))
-    ostream.write(tabulate.tabulate(rows, tablefmt="psql"))
+    
+    table = Table(box=box.ASCII2, show_header=False)
+    for row in rows:
+        table.add_row(str(row[0]), str(row[1]))
 
-    ostream.write("\n")
+    console.print(table)
+
 
 
 def render_string_type_rows(results: ResultDocument) -> List[Tuple[str, str]]:
@@ -131,21 +138,21 @@ def strtime(seconds):
     return f"{m:02.0f}:{s:02.0f}"
 
 
-def render_static_substrings(strings, encoding, offset_len, ostream, verbose, disable_headers):
+def render_static_substrings(strings, encoding, offset_len, console, verbose, disable_headers):
     if verbose != Verbosity.DEFAULT:
         encoding = heading_style(encoding)
-    render_sub_heading(f"FLOSS STATIC STRINGS: {encoding}", len(strings), ostream, disable_headers)
+    render_sub_heading(f"FLOSS STATIC STRINGS: {encoding}", len(strings), console, disable_headers)
     for s in strings:
         if verbose == Verbosity.DEFAULT:
-            ostream.writeln(s.string)
+            console.print(s.string)
         else:
             colored_string = string_style(s.string)
-            ostream.writeln(f"0x{s.offset:>0{offset_len}x} {colored_string}")
-    ostream.writeln("")
+            console.print(f"0x{s.offset:>0{offset_len}x} {colored_string}")
+    console.print("\n")
 
 
-def render_staticstrings(strings, ostream, verbose, disable_headers):
-    render_heading("FLOSS STATIC STRINGS", len(strings), ostream, verbose, disable_headers)
+def render_staticstrings(strings, console, verbose, disable_headers):
+    render_heading("FLOSS STATIC STRINGS", len(strings), console, verbose, disable_headers)
 
     ascii_strings = list(filter(lambda s: s.encoding == StringEncoding.ASCII, strings))
     unicode_strings = list(filter(lambda s: s.encoding == StringEncoding.UTF16LE, strings))
@@ -158,67 +165,65 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
         unicode_offset_len = len(f"{unicode_strings[-1].offset}")
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
-    render_static_substrings(ascii_strings, "ASCII", offset_len, ostream, verbose, disable_headers)
-    render_static_substrings(unicode_strings, "UTF-16LE", offset_len, ostream, verbose, disable_headers)
+    render_static_substrings(ascii_strings, "ASCII", offset_len, console, verbose, disable_headers)
+    render_static_substrings(unicode_strings, "UTF-16LE", offset_len, console, verbose, disable_headers)
 
 
 def render_stackstrings(
-    strings: Union[List[StackString], List[TightString]], ostream, verbose: bool, disable_headers: bool
+    strings: Union[List[StackString], List[TightString]], console, verbose: bool, disable_headers: bool
 ):
     if verbose == Verbosity.DEFAULT:
         for s in strings:
-            ostream.writeln(sanitize(s.string))
+            console.print(sanitize(s.string))
     else:
         if strings:
-            ostream.write(
-                tabulate.tabulate(
-                    [
-                        (
-                            util.hex(s.function),
+            
+            table = Table("Function", "Function Offset", "Frame Offset", "String", show_header=not(disable_headers))
+            for s in strings:
+                table.add_row(util.hex(s.function),
                             util.hex(s.program_counter),
                             util.hex(s.frame_offset),
-                            string_style(sanitize(s.string)),
-                        )
-                        for s in strings
-                    ],
-                    headers=("Function", "Function Offset", "Frame Offset", "String") if not disable_headers else (),
-                )
-            )
-            ostream.write("\n")
+                            string_style(sanitize(s.string)))
+                            
+            console.print(table)
+            console.print("\n")
+            
 
 
-def render_decoded_strings(decoded_strings: List[DecodedString], ostream, verbose, disable_headers):
+def render_decoded_strings(decoded_strings: List[DecodedString], console, verbose, disable_headers):
     """
     Render results of string decoding phase.
     """
     if verbose == Verbosity.DEFAULT:
         for ds in decoded_strings:
-            ostream.writeln(sanitize(ds.string))
+            console.print(sanitize(ds.string))
     else:
         strings_by_functions = collections.defaultdict(list)
         for ds in decoded_strings:
             strings_by_functions[ds.decoding_routine].append(ds)
 
         for fva, data in strings_by_functions.items():
-            render_sub_heading(" FUNCTION at " + heading_style(f"0x{fva:x}"), len(data), ostream, disable_headers)
+            render_sub_heading(" FUNCTION at " + heading_style(f"0x{fva:x}"), len(data), console, disable_headers)
             rows = []
             for ds in data:
                 if ds.address_type == AddressType.STACK:
-                    offset_string = "[stack]"
+                    offset_string = "Stack"
                 elif ds.address_type == AddressType.HEAP:
-                    offset_string = "[heap]"
+                    offset_string = "Heap"
                 else:
                     offset_string = hex(ds.address or 0)
                 rows.append((offset_string, hex(ds.decoded_at), string_style(ds.string)))
 
             if rows:
-                ostream.write(
-                    tabulate.tabulate(rows, headers=("Offset", "Called At", "String") if not disable_headers else ())
-                )
-                ostream.writeln("\n")
+                table = Table("Offset", "Called At", "String", show_header=not(disable_headers), box=box.ASCII2, show_edge=False)
+                for row in rows:
+                    table.add_row(row[0], row[1], row[2])
+                console.print(table)
+                console.print('\n')
 
 
-def render_heading(heading, n, ostream, verbose, disable_headers):
+
+def render_heading(heading, n, console, verbose, disable_headers):
     """
     example::
 
@@ -228,16 +233,19 @@ def render_heading(heading, n, ostream, verbose, disable_headers):
     """
     if disable_headers:
         return
-    heading = f"‖ {heading} ({n}) ‖"
-    table = tabulate.tabulate([[heading]], tablefmt="rst")
+    style = ""
+    if verbose != Verbosity.DEFAULT:
+        style = "cyan"
+    table = Table(box=box.HORIZONTALS, style=style, show_header=False)
+    table.add_row(heading, style=style)
     if verbose == Verbosity.DEFAULT:
-        ostream.write(table)
+        console.print(table)
     else:
-        ostream.write(heading_style(table))
-    ostream.write("\n")
+        console.print(table)
+    console.print()
 
 
-def render_sub_heading(heading, n, ostream, disable_headers):
+def render_sub_heading(heading, n, console, disable_headers):
     """
     example::
 
@@ -247,40 +255,42 @@ def render_sub_heading(heading, n, ostream, disable_headers):
     """
     if disable_headers:
         return
-    heading = f"{heading} ({n})"
-    ostream.write(tabulate.tabulate([[heading]], tablefmt="psql"))
-    ostream.write("\n")
+    table = Table(box=box.ASCII2, show_header=False)
+    table.add_row(heading)
+    console.print(table)
+    console.print()
 
 
 def render(results, verbose, disable_headers):
-    ostream = StringIO()
+    console = Console(file=io.StringIO(), color_system='256', highlight=False)
 
     if not disable_headers:
-        ostream.writeln("")
+        console.print('\n')
         if verbose == Verbosity.DEFAULT:
-            ostream.write(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
+            console.print(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
         else:
             colored_str = heading_style(f"FLARE FLOSS RESULTS (version {results.metadata.version})\n")
-            ostream.write(colored_str)
-        render_meta(results, ostream, verbose)
-        ostream.writeln("")
+            console.print(colored_str)
+        render_meta(results, console, verbose)
+        console.print('\n')
 
     if results.analysis.enable_static_strings:
-        render_staticstrings(results.strings.static_strings, ostream, verbose, disable_headers)
-        ostream.writeln("")
+        render_staticstrings(results.strings.static_strings, console, verbose, disable_headers)
+        console.print('\n')
 
     if results.analysis.enable_stack_strings:
-        render_heading("FLOSS STACK STRINGS", len(results.strings.stack_strings), ostream, verbose, disable_headers)
-        render_stackstrings(results.strings.stack_strings, ostream, verbose, disable_headers)
-        ostream.writeln("")
+        render_heading("FLOSS STACK STRINGS", len(results.strings.stack_strings), console, verbose, disable_headers)
+        render_stackstrings(results.strings.stack_strings, console, verbose, disable_headers)
+        console.print('\n')
 
     if results.analysis.enable_tight_strings:
-        render_heading("FLOSS TIGHT STRINGS", len(results.strings.tight_strings), ostream, verbose, disable_headers)
-        render_stackstrings(results.strings.tight_strings, ostream, verbose, disable_headers)
-        ostream.writeln("")
+        render_heading("FLOSS TIGHT STRINGS", len(results.strings.tight_strings), console, verbose, disable_headers)
+        render_stackstrings(results.strings.tight_strings, console, verbose, disable_headers)
+        console.print('\n')
 
     if results.analysis.enable_decoded_strings:
-        render_heading("FLOSS DECODED STRINGS", len(results.strings.decoded_strings), ostream, verbose, disable_headers)
-        render_decoded_strings(results.strings.decoded_strings, ostream, verbose, disable_headers)
+        render_heading("FLOSS DECODED STRINGS", len(results.strings.decoded_strings), console, verbose, disable_headers)
+        render_decoded_strings(results.strings.decoded_strings, console, verbose, disable_headers)
 
-    return ostream.getvalue()
+    return console.file.getvalue()
+

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     "halo==0.0.31",
     "termcolor==2.2.0",
     "colorama==0.4.6",
+    "rich==12.6.0",
 ]
 
 # this sets __version__

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ requirements = [
     "tqdm==4.65.0",
     "networkx==2.5.1",
     "halo==0.0.31",
-    "termcolor==2.2.0",
-    "colorama==0.4.6",
     "rich==12.6.0",
 ]
 
@@ -69,7 +67,6 @@ setuptools.setup(
             # type stubs for mypy
             "types-PyYAML==6.0.10",
             "types-tabulate==0.9.0.1",
-            "types-colorama==0.4.15.8",
         ],
         "build": [
             "pyinstaller==5.9.0",


### PR DESCRIPTION
Changes:-
- Replacing termcolor with rich
- Removed --outfile cli parameter
- Moved write function inline

Screenshots :-

1) Command --> `floss -v [executable name]`
<p float="left">
<img width="50%" src="https://user-images.githubusercontent.com/94680887/228426103-2283a6fb-091a-4936-bd94-64ae38bf291f.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/228426113-7048055d-9844-43f8-9737-249f08588dd3.png">
</p>

2) Command --> `floss -v [executable name] --color never]`
<p float="left">
<img width="50%" src="https://user-images.githubusercontent.com/94680887/228426124-bb63b126-d273-424b-99a3-975418bb63e4.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/228426117-6afdb02c-c6c3-4eb9-b935-a1a8a51d75e4.png">
</p>

3) Command --> `floss -v [executable name] > file`

<p float="left">
<img width="50%" src="https://user-images.githubusercontent.com/94680887/228427341-3646ad7c-8bb4-4256-ab5b-a6fb9d4b3216.png">
<img width="49%" src="">
</p>