### PR TITLE
Fix mypy 1.1.1 integration error of PR #656

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Lint with black
       run: black -l 120 --check .
     - name: Check types with mypy
-      run: mypy --config-file .github/mypy/mypy.ini floss/ scripts/ tests/
+      run: mypy --config-file .github/mypy/mypy.ini --check-untyped-defs floss/ scripts/ tests/
 
   tests:
     name: Tests in ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -178,7 +178,15 @@ def extract_stackstrings(
                 )
                 for s in extract_strings(ctx.stack_memory, min_length, seen):
                     frame_offset = (ctx.init_sp - ctx.sp) - s.offset - getPointerSize(vw)
-                    ss = StackString(fva, s.string, s.encoding, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset)
+                    ss = StackString(function=fva,
+                                     string=s.string,
+                                     encoding=s.encoding,
+                                     program_counter=ctx.pc,
+                                     stack_pointer=ctx.sp,
+                                     original_stack_pointer=ctx.init_sp,
+                                     offset=s.offset,
+                                     frame_offset=frame_offset
+                                    )
                     floss.results.log_result(ss, verbosity)
                     seen.add(s.string)
                     stack_strings.append(ss)

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -163,12 +163,12 @@ def decode_strings(
                     for delta_bytes in extract_delta_bytes(delta, ctx.decoded_at_va, fva):
                         for s in floss.utils.extract_strings(delta_bytes.bytes, min_length, seen):
                             ds = DecodedString(
-                                delta_bytes.address + s.offset,
-                                delta_bytes.address_type,
-                                s.string,
-                                s.encoding,
-                                delta_bytes.decoded_at,
-                                delta_bytes.decoding_routine,
+                                address=delta_bytes.address + s.offset,
+                                address_type=delta_bytes.address_type,
+                                string=s.string,
+                                encoding=s.encoding,
+                                decoded_at=delta_bytes.decoded_at,
+                                decoding_routine=delta_bytes.decoding_routine,
                             )
                             floss.results.log_result(ds, verbosity)
                             seen.add(ds.string)

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -52,7 +52,7 @@ def extract_ascii_strings(buf, n=MIN_LENGTH) -> Iterable[StaticString]:
         reg = rb"([%s]{%d,})" % (ASCII_BYTE, n)
         r = re.compile(reg)
     for match in r.finditer(buf):
-        yield StaticString(match.group().decode("ascii"), offset=match.start(), encoding=StringEncoding.ASCII)
+        yield StaticString(string=match.group().decode("ascii"), offset=match.start(), encoding=StringEncoding.ASCII)
 
 
 def extract_unicode_strings(buf, n=MIN_LENGTH) -> Iterable[StaticString]:
@@ -79,7 +79,7 @@ def extract_unicode_strings(buf, n=MIN_LENGTH) -> Iterable[StaticString]:
         r = re.compile(reg)
     for match in r.finditer(buf):
         try:
-            yield StaticString(match.group().decode("utf-16"), offset=match.start(), encoding=StringEncoding.UTF16LE)
+            yield StaticString(string=match.group().decode("utf-16"), offset=match.start(), encoding=StringEncoding.UTF16LE)
         except UnicodeDecodeError:
             pass
 

--- a/floss/tightstrings.py
+++ b/floss/tightstrings.py
@@ -109,7 +109,15 @@ def extract_tightstrings(
                     logger.trace("pre_ctx strings: %s", ctx.pre_ctx_strings)
                     for s in extract_strings(ctx.stack_memory, min_length, exclude=ctx.pre_ctx_strings):
                         frame_offset = (ctx.init_sp - ctx.sp) - s.offset - floss.utils.getPointerSize(vw)
-                        ts = TightString(fva, s.string, s.encoding, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset)
+                        ts = TightString(function=fva,
+                                         string=s.string,
+                                         encoding=s.encoding,
+                                         program_counter=ctx.pc,
+                                         stack_pointer=ctx.sp,
+                                         original_stack_pointer=ctx.init_sp,
+                                         offset=s.offset,
+                                         frame_offset=frame_offset
+                                        )
                         floss.results.log_result(ts, verbosity)
                         tight_strings.append(ts)
     return tight_strings

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -231,7 +231,7 @@ def extract_strings(buffer: bytes, min_length: int, exclude: Optional[Set[str]] 
         if exclude and decoded_string in exclude:
             continue
 
-        yield StaticString(decoded_string, s.offset, s.encoding)
+        yield StaticString(string=decoded_string, offset=s.offset, encoding=s.encoding)
 
 
 # FP string starts

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setuptools.setup(
             "pycodestyle==2.10.0",
             "black==23.1.0",
             "isort==5.11.4",
-            "mypy==1.0.1",
+            "mypy==1.1.1",
             # type stubs for mypy
             "types-PyYAML==6.0.10",
             "types-tabulate==0.9.0.1",


### PR DESCRIPTION
Specified argument's keywords when using string classes defined in 'floss/results'