### PR TITLE
Added docs for scripts in FLOSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ For a detailed description of *testing* FLOSS, review the documentation
 ## Scripts
 FLOSS also contains additional python scripts in the [scripts](scripts) folder 
 which can be used to load its output into other tools such as Binary Ninja or IDA pro.
-For detailed description of these scripts review the documentation [here]
+For detailed description of these scripts review the documentation [here](scripts/README.md).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ For a detailed description of *testing* FLOSS, review the documentation
 
 
 ## Scripts
-FLOSS also contains additional python scripts in the [scripts](scripts) folder 
+FLOSS also contains additional Python scripts in the [scripts](scripts) folder 
 which can be used to load its output into other tools such as Binary Ninja or IDA pro.
 For detailed description of these scripts review the documentation [here](scripts/README.md).

--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ For a detailed description of *testing* FLOSS, review the documentation
 
 ## Scripts
 FLOSS also contains additional Python scripts in the [scripts](scripts) folder 
-which can be used to load its output into other tools such as Binary Ninja or IDA pro.
+which can be used to load its output into other tools such as Binary Ninja or IDA Pro.
 For detailed description of these scripts review the documentation [here](scripts/README.md).

--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ For a detailed description of *using* FLOSS, review the documentation
 
 For a detailed description of *testing* FLOSS, review the documentation
  [here](doc/test.md).
+
+
+## Scripts
+FLOSS also contains additional python scripts in the [scripts](scripts) folder 
+which can be used to load its output into other tools such as Binary Ninja or IDA pro.
+For detailed description of these scripts review the documentation [here]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ To install FLOSS as source, see the documentation [here](../doc/installation.md)
 - Run FLOSS on the desired executable with the `-j` or `--json` argument to emit a JSON result
 and redirect it to a JSON file.
 
-    $ floss -j suspicious.exe > floss_results.json
+    `$ floss -j suspicious.exe > floss_results.json`
 
 For Binary Ninja, IDA Pro, Ghidra or Radare2:
 - Run the script for your tool of choice by passing the result json file as an argument and
@@ -24,13 +24,13 @@ redirect the output to a Python (.py) file.
 
 Ghidra Example:
 
-    $ python render-ghidra-import-script.py floss_results.json > apply_floss.py
+    `$ python render-ghidra-import-script.py floss_results.json > apply_floss.py`
 
 - Run the Python script `apply_floss.py` using the desired tool.
 
 For x64dbg:
 - Instead of a Python file, redirect the output to a .json file.
 
-    $ python render-x64dbg-database.py floss-results.json > database.json
+    `$ python render-x64dbg-database.py floss-results.json > database.json`
 
 - Open the JSON file `database.json` in x64dbg.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,4 @@
-# FLARE Obfuscated String Solver
-
-## Scripts
+# FLOSS Scripts
 FLOSS currently supports converting its output into scripts for the following tools:
 1. [IDA pro](render-ida-import-script.py)
 2. [Binary Ninja](render-binja-import-script.py)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,10 +1,5 @@
 # FLOSS Scripts
 FLOSS supports converting its output into scripts for various tools. Please see the render scripts in this directory.
-1. [IDA pro](render-ida-import-script.py)
-2. [Binary Ninja](render-binja-import-script.py)
-3. [Ghidra](render-ghidra-import-script.py)
-4. [Radare2](render-r2-import-script.py)
-5. [X64dbg](render-x64dbg-database.py)
   
 Additionally, there is another [plugin for IDA](idaplugin.py) to allow FLOSS to automatically
 extract obfuscated strings and apply them to the currently loaded module in IDA.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,29 +11,29 @@ To install FLOSS as source, see the documentation [here](../doc/installation.md)
 
 
 # Usage
-#### To convert FLOSS output into scripts for tools:
+## Convert FLOSS output for use by other tools
 
-- Run FLOSS on the desired executable with the -j or --json argument to emit a JSON result
+- Run FLOSS on the desired executable with the `-j` or `--json` argument to emit a JSON result
 and redirect it to a JSON file.
 
     $ floss -j suspicious.exe > floss_results.json
 
-For Binary Ninja, IDA, Ghidra or Radare2,
-- Run the script for your tool of choice by passing the result json as an argument and
-redirect the output to a Python(.py) file.  
+For Binary Ninja, IDA Pro, Ghidra or Radare2:
+- Run the script for your tool of choice by passing the result json file as an argument and
+redirect the output to a Python (.py) file.  
 
 Ghidra Example:
 
     $ python render-ghidra-import-script.py floss_results.json > apply_floss.py
 
-- Run the new python file apply_floss.py in the tool you made it for.
+- Run the Python script `apply_floss.py` using the desired tool.
 
-For x64dbg,
-- Instead of a python file, redirect the output to a .json file.
+For x64dbg:
+- Instead of a Python file, redirect the output to a .json file.
 
 
     $ python render-x64dbg-database.py floss-results.json > database.json
 
-- Open the JSON file database.json in x64dbg.
+- Open the JSON file `database.json` in x64dbg.
 
 #### To run the IDA plugin:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ To install FLOSS as source, see the documentation [here](../doc/installation.md)
 ## Convert FLOSS output for use by other tools
 
 - Run FLOSS on the desired executable with the `-j` or `--json` argument to emit a JSON result
-and redirect it to a JSON file.
+and redirect it to a JSON file.  
     `$ floss -j suspicious.exe > floss_results.json`
 
 For Binary Ninja, IDA Pro, Ghidra or Radare2:
@@ -27,7 +27,7 @@ Ghidra Example:
 - Run the Python script `apply_floss.py` using the desired tool.
 
 For x64dbg:
-- Instead of a Python file, redirect the output to a .json file.
+- Instead of a Python file, redirect the output to a .json file.  
     `$ python render-x64dbg-database.py floss-results.json > database.json`
 
 - Open the JSON file `database.json` in x64dbg.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,22 +15,19 @@ To install FLOSS as source, see the documentation [here](../doc/installation.md)
 
 - Run FLOSS on the desired executable with the `-j` or `--json` argument to emit a JSON result
 and redirect it to a JSON file.
-
     `$ floss -j suspicious.exe > floss_results.json`
 
 For Binary Ninja, IDA Pro, Ghidra or Radare2:
 - Run the script for your tool of choice by passing the result json file as an argument and
 redirect the output to a Python (.py) file.  
 
-Ghidra Example:
-
+Ghidra Example:  
     `$ python render-ghidra-import-script.py floss_results.json > apply_floss.py`
 
 - Run the Python script `apply_floss.py` using the desired tool.
 
 For x64dbg:
 - Instead of a Python file, redirect the output to a .json file.
-
     `$ python render-x64dbg-database.py floss-results.json > database.json`
 
 - Open the JSON file `database.json` in x64dbg.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,37 @@
+# FLARE Obfuscated String Solver
+
+## Scripts
+FLOSS currently supports converting its outputs into scripts for
+the following tools:
+1. [IDA pro](render-ida-import-script.py)
+2. [Binary Ninja](render-binja-import-script.py)
+3. [Ghidra](render-ghidra-import-script.py)
+4. [Radare2](render-r2-import-script.py)
+5. [X64dbg](render-x64dbg-database.py)
+  
+Additionally, there is another [plugin for IDA](idaplugin.py) to allow FLOSS to
+automatically extract obfuscated strings and apply them to the
+currently loaded module in IDA.
+
+# Installation
+These scripts can be downloaded from the FLOSS [GitHub](https://github.com/mandiant/flare-floss) repository
+alongside the source, which is required for the scripts to run.
+To install FLOSS, see the documentation [here](../doc/installation.md).
+
+
+# Usage
+To convert FLOSS output into scripts for tools:
+
+Run FLOSS on the desired executable with the JSON argument to emit a JSON result
+and redirect it to a JSON file.
+
+    $ floss -j suspicious.exe > floss_results.json
+
+Run the script for your tool of choice, pass the result json as an argument and
+redirect the output to a Python(.py) file.
+
+    $ python render-tool-import-script.py floss_results.json > apply_floss.py
+
+Run the new python file in the tool you made it for.
+
+To run the IDA plugin,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,18 +20,20 @@ To install FLOSS, see the documentation [here](../doc/installation.md).
 
 
 # Usage
-To convert FLOSS output into scripts for tools:
+#### To convert FLOSS output into scripts for tools:
 
-Run FLOSS on the desired executable with the JSON argument to emit a JSON result
+- Run FLOSS on the desired executable with the JSON argument to emit a JSON result
 and redirect it to a JSON file.
+
 
     $ floss -j suspicious.exe > floss_results.json
 
-Run the script for your tool of choice, pass the result json as an argument and
+- Run the script for your tool of choice, pass the result json as an argument and
 redirect the output to a Python(.py) file.
+
 
     $ python render-tool-import-script.py floss_results.json > apply_floss.py
 
-Run the new python file in the tool you made it for.
+- Run the new python file in the tool you made it for.
 
-To run the IDA plugin,
+#### To run the IDA plugin,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 FLOSS supports converting its output into scripts for various tools. Please see the render scripts in this directory.
   
 Additionally, there is another [plugin for IDA](idaplugin.py) to allow FLOSS to automatically
-extract obfuscated strings and apply them to the currently loaded module in IDA.
+extract obfuscated strings and apply them to the currently loaded module in IDA. `idaplugin.py` is a IDAPython script you can directly run within IDA Pro (File - Script File... [ALT + F7]).
 
 # Installation
 These scripts can be downloaded from the FLOSS [GitHub](https://github.com/mandiant/flare-floss) repository

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,35 +1,33 @@
 # FLARE Obfuscated String Solver
 
 ## Scripts
-FLOSS currently supports converting its outputs into scripts for
-the following tools:
+FLOSS currently supports converting its output into scripts for the following tools:
 1. [IDA pro](render-ida-import-script.py)
 2. [Binary Ninja](render-binja-import-script.py)
 3. [Ghidra](render-ghidra-import-script.py)
 4. [Radare2](render-r2-import-script.py)
 5. [X64dbg](render-x64dbg-database.py)
   
-Additionally, there is another [plugin for IDA](idaplugin.py) to allow FLOSS to
-automatically extract obfuscated strings and apply them to the
-currently loaded module in IDA.
+Additionally, there is another [plugin for IDA](idaplugin.py) to allow FLOSS to automatically
+extract obfuscated strings and apply them to the currently loaded module in IDA.
 
 # Installation
 These scripts can be downloaded from the FLOSS [GitHub](https://github.com/mandiant/flare-floss) repository
 alongside the source, which is required for the scripts to run.
-To install FLOSS, see the documentation [here](../doc/installation.md).
+To install FLOSS as source, see the documentation [here](../doc/installation.md).
 
 
 # Usage
 #### To convert FLOSS output into scripts for tools:
 
-- Run FLOSS on the desired executable with the JSON argument to emit a JSON result
+- Run FLOSS on the desired executable with the -j or --json argument to emit a JSON result
 and redirect it to a JSON file.
 
 
     $ floss -j suspicious.exe > floss_results.json
 
 For Binary Ninja, IDA, Ghidra or Radare2,
-- Run the script for your tool of choice, pass the result json as an argument and
+- Run the script for your tool of choice by passing the result json as an argument and
 redirect the output to a Python(.py) file.
 
 IDA
@@ -56,6 +54,6 @@ For x64dbg,
 
     $ python render-x64dbg-database.py floss-results.json > database.json
 
-- Then, open the JSON file database.json in x64dbg.
+- Open the JSON file database.json in x64dbg.
 
 #### To run the IDA plugin,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,8 +32,21 @@ For Binary Ninja, IDA, Ghidra or Radare2,
 - Run the script for your tool of choice, pass the result json as an argument and
 redirect the output to a Python(.py) file.
 
+IDA
 
-    $ python render-tool-import-script.py floss_results.json > apply_floss.py
+      $ python render-ida-import-script.py floss_results.json > apply_floss.py
+
+Binary Ninja
+
+    $ python render-binja-import-script.py floss_results.json > apply_floss.py
+
+Ghidra
+
+    $ python render-ghidra-import-script.py floss_results.json > apply_floss.py
+
+Radare2
+
+    $ python render-r2-import-script.py floss_results.json > apply_floss.py
 
 - Run the new python file apply_floss.py in the tool you made it for.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,23 +20,11 @@ and redirect it to a JSON file.
 
 For Binary Ninja, IDA, Ghidra or Radare2,
 - Run the script for your tool of choice by passing the result json as an argument and
-redirect the output to a Python(.py) file.
+redirect the output to a Python(.py) file.  
 
-IDA
-
-      $ python render-ida-import-script.py floss_results.json > apply_floss.py
-
-Binary Ninja
-
-    $ python render-binja-import-script.py floss_results.json > apply_floss.py
-
-Ghidra
+Ghidra Example:
 
     $ python render-ghidra-import-script.py floss_results.json > apply_floss.py
-
-Radare2
-
-    $ python render-r2-import-script.py floss_results.json > apply_floss.py
 
 - Run the new python file apply_floss.py in the tool you made it for.
 
@@ -48,4 +36,4 @@ For x64dbg,
 
 - Open the JSON file database.json in x64dbg.
 
-#### To run the IDA plugin,
+#### To run the IDA plugin:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,5 @@
 # FLOSS Scripts
-FLOSS currently supports converting its output into scripts for the following tools:
+FLOSS supports converting its output into scripts for various tools. Please see the render scripts in this directory.
 1. [IDA pro](render-ida-import-script.py)
 2. [Binary Ninja](render-binja-import-script.py)
 3. [Ghidra](render-ghidra-import-script.py)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,9 +31,6 @@ Ghidra Example:
 For x64dbg:
 - Instead of a Python file, redirect the output to a .json file.
 
-
     $ python render-x64dbg-database.py floss-results.json > database.json
 
 - Open the JSON file `database.json` in x64dbg.
-
-#### To run the IDA plugin:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,6 @@ To install FLOSS as source, see the documentation [here](../doc/installation.md)
 - Run FLOSS on the desired executable with the -j or --json argument to emit a JSON result
 and redirect it to a JSON file.
 
-
     $ floss -j suspicious.exe > floss_results.json
 
 For Binary Ninja, IDA, Ghidra or Radare2,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,12 +28,21 @@ and redirect it to a JSON file.
 
     $ floss -j suspicious.exe > floss_results.json
 
+For Binary Ninja, IDA, Ghidra or Radare2,
 - Run the script for your tool of choice, pass the result json as an argument and
 redirect the output to a Python(.py) file.
 
 
     $ python render-tool-import-script.py floss_results.json > apply_floss.py
 
-- Run the new python file in the tool you made it for.
+- Run the new python file apply_floss.py in the tool you made it for.
+
+For x64dbg,
+- Instead of a python file, redirect the output to a .json file.
+
+
+    $ python render-x64dbg-database.py floss-results.json > database.json
+
+- Then, open the JSON file database.json in x64dbg.
 
 #### To run the IDA plugin,


### PR DESCRIPTION
Added documentation for scripts within the FLOSS repository by creating a readme.md in the scripts folder and updating the main readme.md to point to the new scripts readme.
I have tried to be as similar in style to FLOSS' existing documentation as possible. Please let me know of any typo, grammar mistake or suggestions to improve these docs. You can view the changes on GitHub [here](https://github.com/symbolicvoid/flare-floss/tree/script-docs).

Some questions I have:
- Can the scripts run if FLOSS was installed as a library and the scripts were installed independently of it?
- Should we make this point to Method 3 of [installation.md](https://github.com/mandiant/flarefloss/blob/master/doc/installation.md#method-3-inspecting-the-floss-source-code)?
```
# Installation
These scripts can be downloaded from the FLOSS [GitHub](https://github.com/mandiant/flare-floss) repository
alongside the source, which is required for the scripts to run.
To install FLOSS as source, see the documentation [here](../doc/installation.md).
```

 Also, for some reason a [code segment](https://github.com/symbolicvoid/flare-floss/blob/script-docs/scripts/README.md#to-convert-floss-output-into-scripts-for-tools) in Usage of scripts/readme doesn't render as code, can someone suggest a fix? It seems to work fine in my IDE, but not here on GitHub.
While here, we could also probably discuss if we need text to show up in -h regarding these scripts.
resolves #558 