### PR TITLE
ci: use bump ubuntu-18.04 to 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           # use old linux so that the shared library versioning is more portable
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             artifact_name: floss
             asset_name: linux
           - os: windows-2019
@@ -50,10 +50,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             artifact_name: floss
             asset_name: linux
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             artifact_name: floss
             asset_name: linux
           - os: windows-2019


### PR DESCRIPTION
ubuntu 18.04 is not deprecated so bump old ubuntu image to use 20.04