### PR TITLE
Remove unused class Architecture

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -343,11 +343,6 @@ def is_supported_file_type(sample_file_path):
         return False
 
 
-class Architecture(str, Enum):
-    i386 = "i386"
-    amd64 = "amd64"
-
-
 def load_vw(
     sample_path: str,
     format: str,


### PR DESCRIPTION
I don't think the class `Architecture` is used. Also, we could use Vivisect to get the architecture of the file if required.