### PR TITLE
Added rich as default traceback handler #623

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -14,9 +14,9 @@ from typing import Set, List, Optional
 
 import halo
 import viv_utils
+import rich.traceback
 import viv_utils.flirt
 from vivisect import VivWorkspace
-from rich.traceback import install
 
 import floss.utils
 import floss.results
@@ -56,9 +56,6 @@ EXTENSIONS_SHELLCODE_32 = ("sc32", "raw32")
 EXTENSIONS_SHELLCODE_64 = ("sc64", "raw64")
 
 logger = floss.logging_.getLogger("floss")
-
-# use rich as default Traceback handler
-install(show_locals=True)
 
 
 class StringType(str, Enum):
@@ -450,6 +447,9 @@ def main(argv=None) -> int:
     arguments:
       argv: the command line arguments
     """
+    # use rich as default Traceback handler
+    rich.traceback.install(show_locals=True)
+
     if argv is None:
         argv = sys.argv[1:]
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -50,6 +50,10 @@ from floss.stackstrings import extract_stackstrings
 from floss.tightstrings import extract_tightstrings
 from floss.string_decoder import decode_strings
 
+#use rich as default Traceback handler
+from rich.traceback import install
+install(show_locals=True)
+
 SIGNATURES_PATH_DEFAULT_STRING = "(embedded signatures)"
 EXTENSIONS_SHELLCODE_32 = ("sc32", "raw32")
 EXTENSIONS_SHELLCODE_64 = ("sc64", "raw64")

--- a/floss/main.py
+++ b/floss/main.py
@@ -16,6 +16,7 @@ import halo
 import viv_utils
 import viv_utils.flirt
 from vivisect import VivWorkspace
+from rich.traceback import install
 
 import floss.utils
 import floss.results
@@ -50,15 +51,14 @@ from floss.stackstrings import extract_stackstrings
 from floss.tightstrings import extract_tightstrings
 from floss.string_decoder import decode_strings
 
-#use rich as default Traceback handler
-from rich.traceback import install
-install(show_locals=True)
-
 SIGNATURES_PATH_DEFAULT_STRING = "(embedded signatures)"
 EXTENSIONS_SHELLCODE_32 = ("sc32", "raw32")
 EXTENSIONS_SHELLCODE_64 = ("sc64", "raw64")
 
 logger = floss.logging_.getLogger("floss")
+
+# use rich as default Traceback handler
+install(show_locals=True)
 
 
 class StringType(str, Enum):


### PR DESCRIPTION
This pull request adds "rich" as the default traceback handler. This will enhance the visual presentation of tracebacks and make it easier for developers to read and understand them. Rich tracebacks are easier to read and show more code than standard Python tracebacks.

Here are some Screenshots:-
<p float="left">
<img width="50%" src="https://user-images.githubusercontent.com/94680887/230808098-ad01355f-c13b-48d7-9508-a2362280bf62.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/230808105-c42699a0-5afb-4417-9d8b-fdd60b77ad4e.png">
</p>

To demonstrate the tracebacks, I intentionally made a small mistake by changing the function name from 'make_parser()' to 'make_parserr()', which caused a NameError because 'make_parserr()' was not defined.
