### PR TITLE
Allow running floss using `python -m floss`

### DIFF
--- a/floss/__main__.py
+++ b/floss/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from floss.main import main
+
+sys.exit(main())


### PR DESCRIPTION
This doesn't need any path setup like the floss entrypoint does.
see https://github.com/psf/black for an example of how this is done in other popular projects.