### PR TITLE
Add Language-Specific Command-Line Flag for Go Binary #830

### DIFF
--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -3,7 +3,7 @@ Programs compiled by the Go compiler use a string representation that is difficu
 
 FLOSS implements an algorithm to handle the unusual characteristics of strings in Go binaries. This approach analyzes instances of the `struct String` type to identify candidate strings and reasons about the length-sorted order to avoid false positives. Crucially, FLOSS automatically handles the complexities of Go strings and displays strings as written in the program's source code.
 
-It's important to mention that there are other types of strings, such as runtime strings, which are not derived from the program strings. While FLOSS may not handle these types directly, it provides valuable insights into the strings originated within the program.
+It's important to mention that there are other types of strings, such as runtime strings, which are not derived from the program strings. 
 
 ### Algorithm:
 

--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -21,7 +21,7 @@ For more information on Go strings, you can refer to the Go project's documentat
 Learn more:
 
     Go Project: [Go Project](https://github.com/golang/go)
-    Blog post: [TITLE OF BLOG](https://medium.com/p/92f6d9fee97c)
+    Blog post: [Unveiling Go Strings: A Google Summer of Code Journey](https://medium.com/p/92f6d9fee97c)
     Source code: 
     - https://github.com/golang/go/blob/36ea4f9680f8296f1c7d0cf7dbb1b3a9d572754a/src/builtin/builtin.go#L70-L73
     - https://github.com/golang/go/blob/38e2376f35907ebbb98419f1f4b8f28125bf6aaf/src/go/types/builtins.go#L824-L825

--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -5,7 +5,7 @@ FLOSS implements an algorithm to handle the unusual characteristics of strings i
 
 It's important to mention that there are other types of strings, such as runtime strings, which are not derived from the program strings. While FLOSS may not handle these types directly, it provides valuable insights into the strings originated within the program.
 
-### Algorithm:-
+### Algorithm:
 
 1. Analyze the struct string instances within the binary.
     - In Go, a struct string represents a string value. It consists of two components: a pointer to the string's underlying data and the length of the string.

--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -3,6 +3,8 @@ Programs compiled by the Go compiler use a string representation that is difficu
 
 FLOSS implements an algorithm to handle the unusual characteristics of strings in Go binaries. This approach analyzes instances of the `struct String` type to identify candidate strings and reasons about the length-sorted order to avoid false positives. Crucially, FLOSS automatically handles the complexities of Go strings and displays strings as written in the program's source code.
 
+ It's important to mention that there are other types of strings, such as runtime strings, which are not derived from the program strings. While FLOSS may not handle these types directly, it provides valuable insights into the strings originated within the program.
+
 ### Algorithm:-
 
 1. Analyze the struct string instances within the binary.
@@ -16,3 +18,14 @@ FLOSS implements an algorithm to handle the unusual characteristics of strings i
 7. Split the identified string blob, based on the cross-references available in the binary, effectively separating the individual strings.
 
 By implementing this algorithm, the FLOSS tool is capable of efficiently locating and extracting Go strings from binaries.
+
+Please note that while FLOSS handles many scenarios effectively, there are certain optimizations, such as inlining constants, that may not be fully supported yet. 
+For more information on Go strings, you can refer to the Go project's documentation and the source code of the struct String layout. Feel free to explore these resources to expand your understanding of this fascinating topic.
+
+Learn more:
+
+    Go Project: [Go Project](https://github.com/golang/go)
+    Blogpost: [Blog](https://medium.com/p/92f6d9fee97c)
+    Resources: 
+    - https://github.com/golang/go/blob/36ea4f9680f8296f1c7d0cf7dbb1b3a9d572754a/src/builtin/builtin.go#L70-L73
+    - https://github.com/golang/go/blob/38e2376f35907ebbb98419f1f4b8f28125bf6aaf/src/go/types/builtins.go#L824-L825

--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -1,0 +1,18 @@
+## Go String Extraction
+Programs compiled by the Go compiler use a string representation that is difficult to interpret by humans. Although they are UTF-8 encoded, and therefore show up in the output of `strings.exe`, program strings are not NULL-terminated. This means separate strings within the binary may appear as a large chunk of indistinguishable string data.
+
+FLOSS implements an algorithm to handle the unusual characteristics of strings in Go binaries. This approach analyzes instances of the `struct String` type to identify candidate strings and reasons about the length-sorted order to avoid false positives. Crucially, FLOSS automatically handles the complexities of Go strings and displays strings as written in the program's source code.
+
+### Algorithm:-
+
+1. Analyze the struct string instances within the binary.
+    - In Go, a struct string represents a string value. It consists of two components: a pointer to the string's underlying data and the length of the string.
+    - By examining these instances, we can identify the characteristics of the strings and their locations within the binary.
+2. Identify the longest continuous sequence of monotonically increasing string lengths.
+3. This longest sequence denotes the string blob.
+4. Examine the surrounding bytes to detect the occurrence of the byte sequence 00 00 00 00.
+5. Use the byte sequence as a delimiter to accurately mark the boundaries of the extracted string.
+6. Extract the string blob located between the identified boundaries.
+7. Split the identified string blob, based on the cross-references available in the binary, effectively separating the individual strings.
+
+By implementing this algorithm, the FLOSS tool is capable of efficiently locating and extracting Go strings from binaries.

--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -7,25 +7,21 @@ It's important to mention that there are other types of strings, such as runtime
 
 ### Algorithm:
 
-1. Analyze the struct string instances within the binary.
-    - In Go, a struct string represents a string value. It consists of two components: a pointer to the string's underlying data and the length of the string.
-    - By examining these instances, we can identify the characteristics of the strings and their locations within the binary.
-2. Identify the longest continuous sequence of monotonically increasing string lengths.
-3. This longest sequence denotes the string blob.
-4. Examine the surrounding bytes to detect the occurrence of the byte sequence 00 00 00 00.
-5. Use the byte sequence as a delimiter to accurately mark the boundaries of the extracted string.
-6. Extract the string blob located between the identified boundaries.
-7. Split the identified string blob, based on the cross-references available in the binary, effectively separating the individual strings.
+1. Analyze the string instances within the binary.
+    - In Go, strings are encoded as structs (see source code links below) containing two fields: a pointer to the string's underlying data and the length of the string.
+    - By examining these instances, we can identify the strings and their locations within the binary.
+2. Identify the longest continuous sequence of monotonically increasing string lengths to find the string blob.
+3. Use the byte sequence `00 00 00 00` as a delimiter to accurately mark the boundaries of the string blob.
+4. Extract the string blob located between the identified boundaries.
+5. Split the identified string blob, based on the cross-references available in the binary to separate the individual strings.
 
-By implementing this algorithm, the FLOSS tool is capable of efficiently locating and extracting Go strings from binaries.
-
-Please note that while FLOSS handles many scenarios effectively, there are certain optimizations, such as inlining constants, that may not be fully supported yet. 
-For more information on Go strings, you can refer to the Go project's documentation and the source code of the struct String layout. Feel free to explore these resources to expand your understanding of this fascinating topic.
+Please note that while FLOSS handles many scenarios effectively, there are certain optimizations, such as inlined constants, that may not be fully supported yet. 
+For more information on Go strings, you can refer to the Go project's documentation and the source code of the struct String layout.
 
 Learn more:
 
     Go Project: [Go Project](https://github.com/golang/go)
-    Blogpost: [Blog](https://medium.com/p/92f6d9fee97c)
-    Resources: 
+    Blog post: [TITLE OF BLOG](https://medium.com/p/92f6d9fee97c)
+    Source code: 
     - https://github.com/golang/go/blob/36ea4f9680f8296f1c7d0cf7dbb1b3a9d572754a/src/builtin/builtin.go#L70-L73
     - https://github.com/golang/go/blob/38e2376f35907ebbb98419f1f4b8f28125bf6aaf/src/go/types/builtins.go#L824-L825

--- a/doc/language_specific_strings.md
+++ b/doc/language_specific_strings.md
@@ -3,7 +3,7 @@ Programs compiled by the Go compiler use a string representation that is difficu
 
 FLOSS implements an algorithm to handle the unusual characteristics of strings in Go binaries. This approach analyzes instances of the `struct String` type to identify candidate strings and reasons about the length-sorted order to avoid false positives. Crucially, FLOSS automatically handles the complexities of Go strings and displays strings as written in the program's source code.
 
- It's important to mention that there are other types of strings, such as runtime strings, which are not derived from the program strings. While FLOSS may not handle these types directly, it provides valuable insights into the strings originated within the program.
+It's important to mention that there are other types of strings, such as runtime strings, which are not derived from the program strings. While FLOSS may not handle these types directly, it provides valuable insights into the strings originated within the program.
 
 ### Algorithm:-
 

--- a/doc/theory.md
+++ b/doc/theory.md
@@ -54,7 +54,7 @@ Finally, FLOSS diffs the emulator memory states from before and
   8. Extract human-readable strings from memory state difference
 
 ## Go String Extraction
-The Go string extraction algorithm implemented in the FLOSS tool enables efficient retrieval of Go strings from binaries, simplifying reverse engineering and malware analysis tasks. By analyzing the struct string instances and leveraging length-sorted order, this algorithm accurately identifies the string blob. The surrounding byte examination and the use of cross-references further refine the extraction process. With this powerful algorithm, FLOSS empowers users to extract and analyze Go strings with ease, providing valuable insights into the inner workings of Go programs.
+The Go string extraction algorithm implemented in the FLOSS tool is designed to address the unique characteristics of Go strings in binaries, ensuring efficient retrieval during reverse engineering and malware analysis tasks. Go strings are conventionally represented as sequences of 8-bit bytes, often encoding UTF-8 text. Without special handling, the strings within the binary may appear as a large chunk of indistinguishable data. The FLOSS algorithm overcomes this challenge by analyzing struct string instances and leveraging the length-sorted order of strings within the binary. This capability provides valuable insights into the inner workings of Go programs, facilitating comprehensive analysis and understanding.
 
 ### Algorithm:-
 

--- a/doc/theory.md
+++ b/doc/theory.md
@@ -54,7 +54,9 @@ Finally, FLOSS diffs the emulator memory states from before and
   8. Extract human-readable strings from memory state difference
 
 ## Go String Extraction
-The Go string extraction algorithm implemented in the FLOSS tool is designed to address the unique characteristics of Go strings in binaries, ensuring efficient retrieval during reverse engineering and malware analysis tasks. Go strings are conventionally represented as sequences of 8-bit bytes, often encoding UTF-8 text. Without special handling, the strings within the binary may appear as a large chunk of indistinguishable data. The FLOSS algorithm overcomes this challenge by analyzing struct string instances and leveraging the length-sorted order of strings within the binary. This capability provides valuable insights into the inner workings of Go programs, facilitating comprehensive analysis and understanding.
+Programs compiled by the Go compiler use a string representation that is difficult to interpret by humans. Although they are UTF-8 encoded, and therefore show up in the output of `strings.exe`, program strings are not NULL-terminated. This means separate strings within the binary may appear as a large chunk of indistinguishable string data.
+
+FLOSS implements an algorithm to handle the unusual characteristics of strings in Go binaries. This approach analyzes instances of the `struct String` type to identify candidate strings and reasons about the length-sorted order to avoid false positives. Crucially, FLOSS automatically handles the complexities of Go strings and displays strings as written in the program's source code.
 
 ### Algorithm:
 

--- a/doc/theory.md
+++ b/doc/theory.md
@@ -52,3 +52,18 @@ Finally, FLOSS diffs the emulator memory states from before and
   6. Emulate decoder functions using extracted arguments and emulator state
   7. Diff memory state from before and after decoder emulation
   8. Extract human-readable strings from memory state difference
+
+## Go String Extraction
+The Go string extraction algorithm implemented in the FLOSS tool enables efficient retrieval of Go strings from binaries, simplifying reverse engineering and malware analysis tasks. By analyzing the struct string instances and leveraging length-sorted order, this algorithm accurately identifies the string blob. The surrounding byte examination and the use of cross-references further refine the extraction process. With this powerful algorithm, FLOSS empowers users to extract and analyze Go strings with ease, providing valuable insights into the inner workings of Go programs.
+
+### Algorithm:-
+
+1. Analyze the struct string instances within the binary.
+2. Identify the longest continuous sequence of monotonically increasing string lengths.
+3. This longest sequence denotes the string blob.
+4. Examine the surrounding bytes to detect the occurrence of the byte sequence 00 00 00 00.
+5. Use the byte sequence as a delimiter to accurately mark the boundaries of the extracted string.
+6. Extract the string blob located between the identified boundaries.
+7. Split the identified string blob, based on the cross-references available in the binary, effectively separating the individual strings.
+
+By implementing this algorithm, the FLOSS tool is capable of efficiently locating and extracting Go strings from binaries.

--- a/doc/theory.md
+++ b/doc/theory.md
@@ -56,7 +56,7 @@ Finally, FLOSS diffs the emulator memory states from before and
 ## Go String Extraction
 The Go string extraction algorithm implemented in the FLOSS tool is designed to address the unique characteristics of Go strings in binaries, ensuring efficient retrieval during reverse engineering and malware analysis tasks. Go strings are conventionally represented as sequences of 8-bit bytes, often encoding UTF-8 text. Without special handling, the strings within the binary may appear as a large chunk of indistinguishable data. The FLOSS algorithm overcomes this challenge by analyzing struct string instances and leveraging the length-sorted order of strings within the binary. This capability provides valuable insights into the inner workings of Go programs, facilitating comprehensive analysis and understanding.
 
-### Algorithm:-
+### Algorithm:
 
 1. Analyze the struct string instances within the binary.
 2. Identify the longest continuous sequence of monotonically increasing string lengths.

--- a/doc/theory.md
+++ b/doc/theory.md
@@ -52,20 +52,3 @@ Finally, FLOSS diffs the emulator memory states from before and
   6. Emulate decoder functions using extracted arguments and emulator state
   7. Diff memory state from before and after decoder emulation
   8. Extract human-readable strings from memory state difference
-
-## Go String Extraction
-Programs compiled by the Go compiler use a string representation that is difficult to interpret by humans. Although they are UTF-8 encoded, and therefore show up in the output of `strings.exe`, program strings are not NULL-terminated. This means separate strings within the binary may appear as a large chunk of indistinguishable string data.
-
-FLOSS implements an algorithm to handle the unusual characteristics of strings in Go binaries. This approach analyzes instances of the `struct String` type to identify candidate strings and reasons about the length-sorted order to avoid false positives. Crucially, FLOSS automatically handles the complexities of Go strings and displays strings as written in the program's source code.
-
-### Algorithm:
-
-1. Analyze the struct string instances within the binary.
-2. Identify the longest continuous sequence of monotonically increasing string lengths.
-3. This longest sequence denotes the string blob.
-4. Examine the surrounding bytes to detect the occurrence of the byte sequence 00 00 00 00.
-5. Use the byte sequence as a delimiter to accurately mark the boundaries of the extracted string.
-6. Extract the string blob located between the identified boundaries.
-7. Split the identified string blob, based on the cross-references available in the binary, effectively separating the individual strings.
-
-By implementing this algorithm, the FLOSS tool is capable of efficiently locating and extracting Go strings from binaries.

--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -505,6 +505,10 @@ def find_string_blob_range(pe: pefile.PE, struct_strings: List[StructString]) ->
 
     # pick the mid string, so that we avoid any junk data on the edges of the string blob
     run_mid = (run_start + run_end) // 2
+
+    if run_mid == 0:
+        raise ValueError("no string blob found")
+
     instance = struct_strings[run_mid]
 
     s = read_struct_string(pe, instance)

--- a/floss/main.py
+++ b/floss/main.py
@@ -153,6 +153,17 @@ def make_parser(argv):
         help="path to sample to analyze",
     )
 
+    language_group = parser.add_argument_group("language arguments")
+    language_group.add_argument(
+        "-e",
+        "--extract",
+        dest="language",
+        type=str,
+        choices=[l.value for l in Language],
+        default=Language.UNKNOWN.value,
+        help="language of the sample",
+    )
+
     analysis_group = parser.add_argument_group("analysis arguments")
     analysis_group.add_argument(
         "--no",
@@ -536,7 +547,7 @@ def main(argv=None) -> int:
     lang_id = identify_language(sample, static_strings)
 
     # set language configurations
-    if lang_id == Language.GO:
+    if (lang_id == Language.GO and args.language == Language.UNKNOWN.value) or args.language == Language.GO.value:
         results.metadata.language = Language.GO.value
 
         if args.enabled_types == [] and args.disabled_types == []:
@@ -554,7 +565,9 @@ def main(argv=None) -> int:
                 analysis.enable_tight_strings = False
                 analysis.enable_decoded_strings = False
 
-    elif lang_id == Language.DOTNET:
+    elif (
+        lang_id == Language.DOTNET and args.language == Language.UNKNOWN.value
+    ) or args.language == Language.DOTNET.value:
         logger.warning(".NET language-specific string extraction is not supported")
         logger.warning(" will NOT deobfuscate any .NET strings")
 
@@ -578,7 +591,9 @@ def main(argv=None) -> int:
         results.metadata.runtime.static_strings = static_runtime
 
         if lang_id:
-            if lang_id == Language.GO:
+            if (
+                lang_id == Language.GO and args.language == Language.UNKNOWN.value
+            ) or args.language == Language.GO.value:
                 logger.info("applying language-specific Go string extraction")
 
                 interim = time()

--- a/floss/main.py
+++ b/floss/main.py
@@ -98,9 +98,9 @@ def make_parser(argv):
         ' 1. static strings:  "regular" ASCII and UTF-16LE strings\n'
         " 2. stack strings:   strings constructed on the stack at run-time\n"
         " 3. tight strings:   special form of stack strings, decoded on the stack\n"
-        " 4. decoded strings: strings decoded in a function\n"
+        " 4. decoded strings: strings decoded in a function\n\n"
 
-        "Language specific strings:"
+        "Language specific strings:\n"
         " 1. Go strings: strings embedded in Go binaries\n"
     )
     epilog = textwrap.dedent(

--- a/floss/main.py
+++ b/floss/main.py
@@ -99,7 +99,6 @@ def make_parser(argv):
         " 2. stack strings:   strings constructed on the stack at run-time\n"
         " 3. tight strings:   special form of stack strings, decoded on the stack\n"
         " 4. decoded strings: strings decoded in a function\n\n"
-
         "Language specific strings:\n"
         " 1. Go strings: strings embedded in Go binaries\n"
     )

--- a/floss/main.py
+++ b/floss/main.py
@@ -99,7 +99,9 @@ def make_parser(argv):
         " 2. stack strings:   strings constructed on the stack at run-time\n"
         " 3. tight strings:   special form of stack strings, decoded on the stack\n"
         " 4. decoded strings: strings decoded in a function\n"
-        " 5. Go strings: strings extracted from Go binaries\n"
+
+        "Language specific strings:"
+        " 1. Go strings: strings embedded in Go binaries\n"
     )
     epilog = textwrap.dedent(
         """

--- a/floss/main.py
+++ b/floss/main.py
@@ -99,6 +99,7 @@ def make_parser(argv):
         " 2. stack strings:   strings constructed on the stack at run-time\n"
         " 3. tight strings:   special form of stack strings, decoded on the stack\n"
         " 4. decoded strings: strings decoded in a function\n"
+        " 5. Go strings: strings extracted from Go binaries\n"
     )
     epilog = textwrap.dedent(
         """


### PR DESCRIPTION
This pull request introduces a language-specific command-line flag, "--extract", to enhance the functionality of our program. The flag allows users to specify the language they want to extract information from, with options for "go", "rust", and "dotnet". Additionally, the flag supports an "unknown" option.

Usage example; `floss -e <language> <binary>`
Resolves #830 
