### PR TITLE
 Add Language-Specific Command-Line Flag for Go Binary #830

### DIFF
--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -505,6 +505,10 @@ def find_string_blob_range(pe: pefile.PE, struct_strings: List[StructString]) ->
 
     # pick the mid string, so that we avoid any junk data on the edges of the string blob
     run_mid = (run_start + run_end) // 2
+
+    if run_mid == 0:
+        raise ValueError("no string blob found")
+
     instance = struct_strings[run_mid]
 
     s = read_struct_string(pe, instance)

--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -505,7 +505,6 @@ def find_string_blob_range(pe: pefile.PE, struct_strings: List[StructString]) ->
 
     # pick the mid string, so that we avoid any junk data on the edges of the string blob
     run_mid = (run_start + run_end) // 2
-
     instance = struct_strings[run_mid]
 
     s = read_struct_string(pe, instance)

--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -506,9 +506,6 @@ def find_string_blob_range(pe: pefile.PE, struct_strings: List[StructString]) ->
     # pick the mid string, so that we avoid any junk data on the edges of the string blob
     run_mid = (run_start + run_end) // 2
 
-    if run_mid == 0:
-        raise ValueError("no string blob found")
-
     instance = struct_strings[run_mid]
 
     s = read_struct_string(pe, instance)
@@ -573,6 +570,9 @@ def get_string_blob_strings(pe: pefile.PE, min_length) -> Iterable[StaticString]
 
     with floss.utils.timing("find struct string candidates"):
         struct_strings = list(sorted(set(get_struct_string_candidates(pe)), key=lambda s: s.address))
+
+    if struct_strings == []:
+        raise ValueError("no struct string candidates found")
 
     with floss.utils.timing("find string blob"):
         string_blob_start, string_blob_end = find_string_blob_range(pe, struct_strings)

--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -572,7 +572,7 @@ def get_string_blob_strings(pe: pefile.PE, min_length) -> Iterable[StaticString]
         struct_strings = list(sorted(set(get_struct_string_candidates(pe)), key=lambda s: s.address))
 
     if struct_strings == []:
-        raise ValueError("no struct string candidates found")
+        raise ValueError("No struct string candidates found. Is this a Go binary?")
 
     with floss.utils.timing("find string blob"):
         string_blob_start, string_blob_end = find_string_blob_range(pe, struct_strings)

--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -569,13 +569,9 @@ def get_string_blob_strings(pe: pefile.PE, min_length) -> Iterable[StaticString]
     image_base = pe.OPTIONAL_HEADER.ImageBase
 
     with floss.utils.timing("find struct string candidates"):
-        try:
-            struct_strings = list(sorted(set(get_struct_string_candidates(pe)), key=lambda s: s.address))
-            if struct_strings == []:
-                raise ValueError("No struct string candidates found. Is this a Go binary?")
-
-        except ValueError as e:
-            logger.warning("Failed to find struct string candidates: %s", e)
+        struct_strings = list(sorted(set(get_struct_string_candidates(pe)), key=lambda s: s.address))
+        if struct_strings == []:
+            logger.warning("Failed to find struct string candidates: Is this a Go binary?")
             return
 
     with floss.utils.timing("find string blob"):

--- a/floss/main.py
+++ b/floss/main.py
@@ -191,7 +191,7 @@ def make_parser(argv):
         type=str,
         choices=[l.value for l in Language if l != Language.UNKNOWN] + ["none"],
         default="",
-        help="language of the sample",
+        help="language of the sample" if show_all_options else argparse.SUPPRESS,
     )
     advanced_group.add_argument(
         "-l",

--- a/floss/main.py
+++ b/floss/main.py
@@ -189,7 +189,7 @@ def make_parser(argv):
     advanced_group.add_argument(
         "--language",
         type=str,
-        choices=[l.value for l in Language],
+        choices=[l.value for l in Language if l != Language.UNKNOWN] + ["none"],
         default="",
         help="language of the sample",
     )

--- a/floss/main.py
+++ b/floss/main.py
@@ -188,7 +188,6 @@ def make_parser(argv):
     )
     advanced_group.add_argument(
         "--language",
-        dest="language",
         type=str,
         choices=[l.value for l in Language],
         default="",

--- a/floss/main.py
+++ b/floss/main.py
@@ -151,6 +151,17 @@ def make_parser(argv):
         help="path to sample to analyze",
     )
 
+    language_group = parser.add_argument_group("language arguments")
+    language_group.add_argument(
+        "-e",
+        "--extract",
+        dest="language",
+        type=str,
+        choices=[l.value for l in Language],
+        default=[],
+        help="language of the sample",
+    )
+
     analysis_group = parser.add_argument_group("analysis arguments")
     analysis_group.add_argument(
         "--no",
@@ -534,7 +545,7 @@ def main(argv=None) -> int:
     lang_id = identify_language(sample, static_strings)
 
     # set language configurations
-    if lang_id == Language.GO:
+    if (lang_id == Language.GO and args.language == []) or args.language == Language.GO.value:
         results.metadata.language = Language.GO.value
 
         if args.enabled_types == [] and args.disabled_types == []:
@@ -552,7 +563,7 @@ def main(argv=None) -> int:
                 analysis.enable_tight_strings = False
                 analysis.enable_decoded_strings = False
 
-    elif lang_id == Language.DOTNET:
+    elif (lang_id == Language.DOTNET and args.language == []) or args.language == Language.DOTNET.value:
         logger.warning(".NET language-specific string extraction is not supported")
         logger.warning(" will NOT deobfuscate any .NET strings")
 
@@ -576,7 +587,7 @@ def main(argv=None) -> int:
         results.metadata.runtime.static_strings = static_runtime
 
         if lang_id:
-            if lang_id == Language.GO:
+            if (lang_id == Language.GO and args.language == []) or args.language == Language.GO.value:
                 logger.info("applying language-specific Go string extraction")
 
                 interim = time()

--- a/floss/main.py
+++ b/floss/main.py
@@ -151,16 +151,6 @@ def make_parser(argv):
         help="path to sample to analyze",
     )
 
-    parser.add_argument(
-        "-g",
-        "--lang",
-        dest="language",
-        type=str,
-        choices=[l.value for l in Language],
-        default="",
-        help="language of the sample",
-    )
-
     analysis_group = parser.add_argument_group("analysis arguments")
     analysis_group.add_argument(
         "--no",
@@ -195,6 +185,14 @@ def make_parser(argv):
         choices=[f[0] for f in formats],
         default="auto",
         help="select sample format, %s" % format_help if show_all_options else argparse.SUPPRESS,
+    )
+    advanced_group.add_argument(
+        "--language",
+        dest="language",
+        type=str,
+        choices=[l.value for l in Language],
+        default="",
+        help="language of the sample",
     )
     advanced_group.add_argument(
         "-l",

--- a/floss/main.py
+++ b/floss/main.py
@@ -151,14 +151,13 @@ def make_parser(argv):
         help="path to sample to analyze",
     )
 
-    language_group = parser.add_argument_group("language arguments")
-    language_group.add_argument(
-        "-e",
-        "--extract",
+    parser.add_argument(
+        "-g",
+        "--lang",
         dest="language",
         type=str,
         choices=[l.value for l in Language],
-        default=[],
+        default="",
         help="language of the sample",
     )
 
@@ -545,7 +544,7 @@ def main(argv=None) -> int:
     lang_id = identify_language(sample, static_strings)
 
     # set language configurations
-    if (lang_id == Language.GO and args.language == []) or args.language == Language.GO.value:
+    if (lang_id == Language.GO and args.language == "") or args.language == Language.GO.value:
         results.metadata.language = Language.GO.value
 
         if args.enabled_types == [] and args.disabled_types == []:
@@ -563,7 +562,7 @@ def main(argv=None) -> int:
                 analysis.enable_tight_strings = False
                 analysis.enable_decoded_strings = False
 
-    elif (lang_id == Language.DOTNET and args.language == []) or args.language == Language.DOTNET.value:
+    elif (lang_id == Language.DOTNET and args.language == "") or args.language == Language.DOTNET.value:
         logger.warning(".NET language-specific string extraction is not supported")
         logger.warning(" will NOT deobfuscate any .NET strings")
 
@@ -587,7 +586,7 @@ def main(argv=None) -> int:
         results.metadata.runtime.static_strings = static_runtime
 
         if lang_id:
-            if (lang_id == Language.GO and args.language == []) or args.language == Language.GO.value:
+            if (lang_id == Language.GO and args.language == "") or args.language == Language.GO.value:
                 logger.info("applying language-specific Go string extraction")
 
                 interim = time()


### PR DESCRIPTION
This pull request introduces a language-specific command-line flag, "--extract", to enhance the functionality of our program. The flag allows users to specify the language they want to extract information from, with options for "go", "rust", and "dotnet". Additionally, the flag supports an "unknown" option.

Usage example; `floss -e <language> <binary>`
Resolves https://github.com/mandiant/flare-floss/issues/830