### PR TITLE
Improve String Extraction in Go Extraction Script for Strings Ending with 0Ah or '\n'

### DIFF
--- a/floss/results.py
+++ b/floss/results.py
@@ -139,7 +139,7 @@ class StaticString:
         except UnicodeDecodeError:
             raise ValueError("not utf-8")
 
-        if not decoded_string.isprintable():
+        if not decoded_string.replace("\n", "").isprintable():
             raise ValueError("not printable")
         if len(decoded_string) < min_length:
             raise ValueError("too short")

--- a/floss/results.py
+++ b/floss/results.py
@@ -139,8 +139,6 @@ class StaticString:
         except UnicodeDecodeError:
             raise ValueError("not utf-8")
 
-        if not decoded_string.replace("\n", "").isprintable():
-            raise ValueError("not printable")
         if len(decoded_string) < min_length:
             raise ValueError("too short")
         return cls(string=decoded_string, offset=addr, encoding=StringEncoding.UTF8)

--- a/tests/test_language_extract_go.py
+++ b/tests/test_language_extract_go.py
@@ -127,13 +127,11 @@ def test_mov_lea_mov(request, string, offset, encoding, go_strings):
 @pytest.mark.parametrize(
     "string,offset,encoding,go_strings",
     [
-        # .text:0000000000481211 48 C7 40 10 19 00 00 00       mov     qword ptr [rax+10h], 19h
-        # .text:0000000000481219 48 8D 0D 71 B6 02 00          lea     rcx, aExpandenvironm ; "ExpandEnvironmentStringsW"
-        # .text:0000000000481220 48 89 48 08                   mov     [rax+8], rcx
+        # 00000000004AB080  20 6E 6F 74 20 66 6F 75  6E 64 20 6D 61 72 6B 72   not found markr
+        # 00000000004AB090  6F 6F 74 20 6A 6F 62 73  20 64 6F 6E 65 0A 20 74  oot jobs done. t
         pytest.param(" markroot jobs done\n", 0xAA68A, StringEncoding.UTF8, "go_strings64"),
-        # .text:0047EACA C7 40 0C 19 00 00 00                          mov     dword ptr [eax+0Ch], 19h
-        # .text:0047EAD1 8D 0D 36 56 4A 00                             lea     ecx, unk_4A5636
-        # .text:0047EAD7 89 48 08                                      mov     [eax+8], ecx
+        # 004A3DE0  66 6F 75 6E 64 20 6D 61  72 6B 72 6F 6F 74 20 6A  found markroot j
+        # 004A3DF0  6F 62 73 20 64 6F 6E 65  0A 20 74 6F 20 75 6E 61  obs done. to una
         pytest.param(" markroot jobs done\n", 0xA23E5, StringEncoding.UTF8, "go_strings32"),
     ],
 )

--- a/tests/test_language_extract_go.py
+++ b/tests/test_language_extract_go.py
@@ -137,7 +137,7 @@ def test_mov_lea_mov(request, string, offset, encoding, go_strings):
         pytest.param(" markroot jobs done\n", 0xA23E5, StringEncoding.UTF8, "go_strings32"),
     ],
 )
-def test_strings_with_0A(request, string, offset, encoding, go_strings):
+def test_strings_with_newline_char_0A(request, string, offset, encoding, go_strings):
     assert StaticString(string=string, offset=offset, encoding=encoding) in request.getfixturevalue(go_strings)
 
 

--- a/tests/test_language_extract_go.py
+++ b/tests/test_language_extract_go.py
@@ -9,14 +9,14 @@ from floss.language.go.extract import extract_go_strings
 @pytest.fixture(scope="module")
 def go_strings32():
     n = 6
-    path = pathlib.Path(__file__).parent / "data" / "src" / "go-hello" / "bin" / "go-hello.exe"
+    path = pathlib.Path(__file__).parent / "data" / "language" / "go" / "go-hello" / "bin" / "go-hello.exe"
     return extract_go_strings(path, n)
 
 
 @pytest.fixture(scope="module")
 def go_strings64():
     n = 6
-    path = pathlib.Path(__file__).parent / "data" / "src" / "go-hello" / "bin" / "go-hello64.exe"
+    path = pathlib.Path(__file__).parent / "data" / "language" / "go" / "go-hello" / "bin" / "go-hello64.exe"
     return extract_go_strings(path, n)
 
 
@@ -124,6 +124,23 @@ def test_mov_lea_mov(request, string, offset, encoding, go_strings):
     assert StaticString(string=string, offset=offset, encoding=encoding) in request.getfixturevalue(go_strings)
 
 
+@pytest.mark.parametrize(
+    "string,offset,encoding,go_strings",
+    [
+        # .text:0000000000481211 48 C7 40 10 19 00 00 00       mov     qword ptr [rax+10h], 19h
+        # .text:0000000000481219 48 8D 0D 71 B6 02 00          lea     rcx, aExpandenvironm ; "ExpandEnvironmentStringsW"
+        # .text:0000000000481220 48 89 48 08                   mov     [rax+8], rcx
+        pytest.param(" markroot jobs done\n", 0xAA68A, StringEncoding.UTF8, "go_strings64"),
+        # .text:0047EACA C7 40 0C 19 00 00 00                          mov     dword ptr [eax+0Ch], 19h
+        # .text:0047EAD1 8D 0D 36 56 4A 00                             lea     ecx, unk_4A5636
+        # .text:0047EAD7 89 48 08                                      mov     [eax+8], ecx
+        pytest.param(" markroot jobs done\n", 0xA23E5, StringEncoding.UTF8, "go_strings32"),
+    ],
+)
+def test_mov_lea_mov(request, string, offset, encoding, go_strings):
+    assert StaticString(string=string, offset=offset, encoding=encoding) in request.getfixturevalue(go_strings)
+
+
 @pytest.mark.skip(reason="not extracted via go_strings")
 @pytest.mark.parametrize(
     "string,offset,encoding,go_strings",
@@ -138,3 +155,5 @@ def test_mov_lea_mov(request, string, offset, encoding, go_strings):
 )
 def test_import_data(request, string, offset, encoding, go_strings):
     assert StaticString(string=string, offset=offset, encoding=encoding) in request.getfixturevalue(go_strings)
+
+

--- a/tests/test_language_extract_go.py
+++ b/tests/test_language_extract_go.py
@@ -9,14 +9,14 @@ from floss.language.go.extract import extract_go_strings
 @pytest.fixture(scope="module")
 def go_strings32():
     n = 6
-    path = pathlib.Path(__file__).parent / "data" / "language" / "go" / "go-hello" / "bin" / "go-hello.exe"
+    path = pathlib.Path(__file__).parent / "data" / "src" / "go-hello" / "bin" / "go-hello.exe"
     return extract_go_strings(path, n)
 
 
 @pytest.fixture(scope="module")
 def go_strings64():
     n = 6
-    path = pathlib.Path(__file__).parent / "data" / "language" / "go" / "go-hello" / "bin" / "go-hello64.exe"
+    path = pathlib.Path(__file__).parent / "data" / "src" / "go-hello" / "bin" / "go-hello64.exe"
     return extract_go_strings(path, n)
 
 
@@ -155,5 +155,3 @@ def test_mov_lea_mov(request, string, offset, encoding, go_strings):
 )
 def test_import_data(request, string, offset, encoding, go_strings):
     assert StaticString(string=string, offset=offset, encoding=encoding) in request.getfixturevalue(go_strings)
-
-

--- a/tests/test_language_extract_go.py
+++ b/tests/test_language_extract_go.py
@@ -137,7 +137,7 @@ def test_mov_lea_mov(request, string, offset, encoding, go_strings):
         pytest.param(" markroot jobs done\n", 0xA23E5, StringEncoding.UTF8, "go_strings32"),
     ],
 )
-def test_mov_lea_mov(request, string, offset, encoding, go_strings):
+def test_strings_with_0A(request, string, offset, encoding, go_strings):
     assert StaticString(string=string, offset=offset, encoding=encoding) in request.getfixturevalue(go_strings)
 
 


### PR DESCRIPTION
This pull request aims to enhance the go extraction script by enabling the extraction of strings ending with `0A` or `'\n'`
See: #837 