### PR TITLE
Handle Empty File Exception in FLOSS Execution

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -540,7 +540,7 @@ def main(argv=None) -> int:
 
     static_strings = get_static_strings(sample, args.min_length)
     if static_strings == []:
-        return 1
+        return 0
 
     static_runtime = get_runtime_diff(interim)
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -537,7 +537,11 @@ def main(argv=None) -> int:
     # can throw away result later if not desired in output
     time0 = time()
     interim = time0
+
     static_strings = get_static_strings(sample, args.min_length)
+    if static_strings == []:
+        return 1
+
     static_runtime = get_runtime_diff(interim)
 
     lang_id = identify_language(sample, static_strings)

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -544,7 +544,7 @@ def get_static_strings(sample: Path, min_length: int) -> list:
     """
 
     if os.stat(sample).st_size == 0:
-        logger.error("File is empty")
+        logger.warning("File is empty")
         return []
 
     with sample.open("r") as f:

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -543,7 +543,7 @@ def get_static_strings(sample: Path, min_length: int) -> list:
     Returns list of static strings from the file which are above the minimum length
     """
 
-    if os.stat(sample).st_size == 0:
+    if sample.stat().st_size == 0:
         logger.warning("File is empty")
         return []
 

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2017 Mandiant, Inc. All Rights Reserved.
+import os
 import re
 import mmap
 import time
@@ -541,6 +542,11 @@ def get_static_strings(sample: Path, min_length: int) -> list:
     """
     Returns list of static strings from the file which are above the minimum length
     """
+
+    if os.stat(sample).st_size == 0:
+        logger.error("File is empty")
+        return []
+
     with sample.open("r") as f:
         if hasattr(mmap, "MAP_PRIVATE"):
             # unix

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2017 Mandiant, Inc. All Rights Reserved.
-import os
 import re
 import mmap
 import time


### PR DESCRIPTION
This PR addresses the issue where running FLOSS on an empty file resulted in an exception (ValueError: cannot mmap an empty file). 

Fixes: #788 