### PR TITLE
Adding tests to ensure >98% string extraction from Unknown go binaries

### DIFF
--- a/floss/language/go/coverage.py
+++ b/floss/language/go/coverage.py
@@ -62,7 +62,7 @@ def main():
     get_extract_stats(pe, static_strings, go_strings, args.min_length)
 
 
-def get_extract_stats(pe, all_ss_strings: List[StaticString], go_strings, min_len) -> int:
+def get_extract_stats(pe, all_ss_strings: List[StaticString], go_strings, min_len) -> float:
     all_strings = list()
     # these are ascii, extract these utf-8 to get fewer chunks (ascii may split on two-byte characters, for example)
     for ss in all_ss_strings:

--- a/floss/language/go/coverage.py
+++ b/floss/language/go/coverage.py
@@ -62,7 +62,7 @@ def main():
     get_extract_stats(pe, static_strings, go_strings, args.min_length)
 
 
-def get_extract_stats(pe, all_ss_strings: List[StaticString], go_strings, min_len):
+def get_extract_stats(pe, all_ss_strings: List[StaticString], go_strings, min_len) -> int:
     all_strings = list()
     # these are ascii, extract these utf-8 to get fewer chunks (ascii may split on two-byte characters, for example)
     for ss in all_ss_strings:
@@ -236,6 +236,8 @@ def get_extract_stats(pe, all_ss_strings: List[StaticString], go_strings, min_le
     print("len gostring chars  :", len_gostr)
     print(f"Percentage of string chars extracted: {round(100 * (len_gostr / len_all_ss))}%")
     print()
+
+    return 100 * (len_gostr / len_all_ss)
 
 
 def get_missed_strings(

--- a/tests/test_language_go_coverage.py
+++ b/tests/test_language_go_coverage.py
@@ -1,0 +1,42 @@
+import pathlib
+
+import pefile
+import pytest
+from floss.utils import get_static_strings
+from IPython.utils import io
+from floss.language.go.extract import extract_go_strings
+from floss.language.go.coverage import get_extract_stats
+
+
+@pytest.mark.parametrize(
+    "binary_file",
+    [
+        ("data/language/go/go-unknown-binaries/bin/386_go1.12"),
+        ("data/language/go/go-unknown-binaries/bin/386_go1.16"),
+        ("data/language/go/go-unknown-binaries/bin/386_go1.18"),
+        ("data/language/go/go-unknown-binaries/bin/386_go1.20"),
+        ("data/language/go/go-unknown-binaries/bin/amd64_go1.12"),
+        ("data/language/go/go-unknown-binaries/bin/amd64_go1.16"),
+        ("data/language/go/go-unknown-binaries/bin/amd64_go1.18"),
+        ("data/language/go/go-unknown-binaries/bin/amd64_go1.20"),
+    ],
+)
+def test_language_detection_64(binary_file):
+    CD = pathlib.Path(__file__).resolve().parent
+    abs_path = (CD / binary_file).resolve()
+
+    assert abs_path.exists(), f"File {binary_file} does not exist"
+
+    n = 4
+
+    all_ss_strings = get_static_strings(abs_path, n)
+    go_strings = extract_go_strings(abs_path, n)
+
+    pe = pefile.PE(abs_path)
+
+    # do not print the output of the function
+    with io.capture_output() as captured:
+        out = get_extract_stats(pe, all_ss_strings, go_strings, n)
+
+    # check that the output percentage is greater than 95%
+    assert out > 95

--- a/tests/test_language_go_coverage.py
+++ b/tests/test_language_go_coverage.py
@@ -2,8 +2,9 @@ import pathlib
 
 import pefile
 import pytest
-from floss.utils import get_static_strings
 from IPython.utils import io
+
+from floss.utils import get_static_strings
 from floss.language.go.extract import extract_go_strings
 from floss.language.go.coverage import get_extract_stats
 
@@ -38,5 +39,5 @@ def test_language_detection_64(binary_file):
     with io.capture_output() as captured:
         out = get_extract_stats(pe, all_ss_strings, go_strings, n)
 
-    # check that the output percentage is greater than 95%
-    assert out > 95
+    # check that the output percentage is greater than 98%
+    assert out > 98

--- a/tests/test_language_go_coverage.py
+++ b/tests/test_language_go_coverage.py
@@ -1,8 +1,8 @@
 import pathlib
+import contextlib
 
 import pefile
 import pytest
-from IPython.utils import io
 
 from floss.utils import get_static_strings
 from floss.language.go.extract import extract_go_strings
@@ -36,7 +36,7 @@ def test_language_detection_64(binary_file):
     pe = pefile.PE(abs_path)
 
     # do not print the output of the function
-    with io.capture_output() as captured:
+    with contextlib.redirect_stdout(None):
         out = get_extract_stats(pe, all_ss_strings, go_strings, n)
 
     # check that the output percentage is greater than 98%


### PR DESCRIPTION
Enhancing string extraction tests for unknown Go binaries to achieve over 98% extraction accuracy.

Fixes: #807 