### PR TITLE
Feature added: file output arg

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2017 Mandiant, Inc. All Rights Reserved.
 import os
 import sys
+import json
 import codecs
 import logging
 import argparse
@@ -759,10 +760,13 @@ def main(argv=None) -> int:
         # this may be slow when there's many strings, so informing users what's happening
         logger.info("rendering results")
         r = floss.render.default.render(results, args.verbose, args.quiet, args.color)
-
+    
     if args.output:
         logger.info("saving into '{}'".format(args.output.name))
-        open(args.output.name, "w").write(r)
+        if args.json:
+            json.dump(json.loads(r), open(args.output.name, "w"), indent=2)
+        else:
+            open(args.output.name, "w").write(r)
     else:
         print(r)
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -274,6 +274,14 @@ def make_parser(argv):
         help="enable ANSI color codes in results, default: only during interactive session",
     )
 
+    // TODO ...
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("w"),
+        help="send output into file",
+    )
+
     return parser
 
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -160,6 +160,13 @@ def make_parser(argv):
         help="path to sample to analyze",
     )
 
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("w"),
+        help="send output into file",
+    )
+
     analysis_group = parser.add_argument_group("analysis arguments")
     analysis_group.add_argument(
         "--no",
@@ -272,14 +279,6 @@ def make_parser(argv):
         choices=("auto", "always", "never"),
         default="auto",
         help="enable ANSI color codes in results, default: only during interactive session",
-    )
-
-    // TODO ...
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=argparse.FileType("w"),
-        help="send output into file",
     )
 
     return parser
@@ -761,7 +760,10 @@ def main(argv=None) -> int:
         logger.info("rendering results")
         r = floss.render.default.render(results, args.verbose, args.quiet, args.color)
 
-    print(r)
+    if args.output:
+        open(args.output.name, "w").write(r)
+    else:
+        print(r)
 
     return 0
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -761,6 +761,7 @@ def main(argv=None) -> int:
         r = floss.render.default.render(results, args.verbose, args.quiet, args.color)
 
     if args.output:
+        logger.info("saving into '{}'".format(args.output.name))
         open(args.output.name, "w").write(r)
     else:
         print(r)


### PR DESCRIPTION
I redirected the rendering output to a `open()` statement in order to write the rendered output to a file. I introduced a new command-line argument to the program, as shown below:

```py
parser.add_argument(
    "-o",
    "--output",
    type=argparse.FileType("w"),
    help="specify an output file",
)
```

Furthermore, I implemented logging to track the process of saving the file:

```py
logger.info("saving to '{}'".format(args.output.name))
```

I have conducted testing, and the functionality works flawlessly.