### PR TITLE
fix extractions and improve language_strings_missed contents

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -54,7 +54,7 @@ from floss.logging_ import TRACE, DebugLevel
 from floss.stackstrings import extract_stackstrings
 from floss.tightstrings import extract_tightstrings
 from floss.string_decoder import decode_strings
-from floss.language.identify import Language, identify_language
+from floss.language.identify import Language, identify_language_and_version
 
 SIGNATURES_PATH_DEFAULT_STRING = "(embedded signatures)"
 EXTENSIONS_SHELLCODE_32 = ("sc32", "raw32")
@@ -198,9 +198,11 @@ def make_parser(argv):
     advanced_group.add_argument(
         "--language",
         type=str,
-        choices=[l.value for l in Language if l != Language.UNKNOWN] + ["none"],
-        default="",
-        help="use language-specific string extraction, disable using 'none'" if show_all_options else argparse.SUPPRESS,
+        choices=[l.value for l in Language if l != Language.UNKNOWN],
+        default=Language.UNKNOWN.value,
+        help="use language-specific string extraction, auto-detect language by default, disable using 'none'"
+        if show_all_options
+        else argparse.SUPPRESS,
     )
     advanced_group.add_argument(
         "-l",
@@ -547,39 +549,44 @@ def main(argv=None) -> int:
     static_runtime = get_runtime_diff(interim)
 
     # set language configurations
-    lang_id: Language
-    if args.language == Language.GO.value:
-        lang_id = Language.GO
-    elif args.language == Language.RUST.value:
-        lang_id = Language.RUST
-    elif args.language == Language.DOTNET.value:
-        lang_id = Language.DOTNET
-    elif args.language == "none":
-        lang_id = Language.UNKNOWN
+    selected_lang = Language(args.language)
+    if selected_lang == Language.DISABLED:
+        results.metadata.language = ""
+        results.metadata.language_version = ""
+        results.metadata.language_selected = ""
     else:
-        lang_id = identify_language(sample, static_strings)
+        lang_id, lang_version = identify_language_and_version(sample, static_strings)
 
-    # TODO(mr-tz): verify user-selected language makes sense and at least warn user
-    #  include language version in results, if available
-    #  https://github.com/mandiant/flare-floss/issues/900
+        if selected_lang == Language.UNKNOWN:
+            pass
+        elif selected_lang != lang_id:
+            logger.warning(
+                "the selected language '%s' differs to the automatically identified language '%s (%s)' - extracted "
+                "strings may be incomplete or inaccurate",
+                selected_lang.value,
+                lang_id.value,
+                lang_version,
+            )
+            results.metadata.language_selected = selected_lang.value
 
-    if lang_id == Language.GO:
+        results.metadata.language = lang_id.value
+        results.metadata.language_version = lang_version
+
+    if results.metadata.language == Language.GO.value:
         if analysis.enable_tight_strings or analysis.enable_stack_strings or analysis.enable_decoded_strings:
             logger.warning(
                 "FLOSS handles Go static strings, but string deobfuscation may be inaccurate and take a long time"
             )
-        results.metadata.language = Language.GO.value
 
-    elif lang_id == Language.RUST:
+    elif results.metadata.language == Language.RUST.value:
         if analysis.enable_tight_strings or analysis.enable_stack_strings or analysis.enable_decoded_strings:
             logger.warning(
                 "FLOSS handles Rust static strings, but string deobfuscation may be inaccurate and take a long time"
             )
-        results.metadata.language = Language.RUST.value
 
-    elif lang_id == Language.DOTNET:
+    elif results.metadata.language == Language.DOTNET.value:
         logger.warning(".NET language-specific string extraction is not supported yet")
-        logger.warning("Furthermore, FLOSS does NOT attempt to deobfuscate any strings from .NET binaries")
+        logger.warning("FLOSS does NOT attempt to deobfuscate any strings from .NET binaries")
 
         # enable .NET strings once we can extract them
         # results.metadata.language = Language.DOTNET.value
@@ -589,7 +596,7 @@ def main(argv=None) -> int:
         analysis.enable_tight_strings = False
         analysis.enable_decoded_strings = False
 
-    if results.metadata.language != "":
+    if results.metadata.language not in ("", "unknown"):
         if args.enabled_types == [] and args.disabled_types == []:
             prompt = input("Do you want to enable string deobfuscation? (this could take a long time) [y/N] ")
 
@@ -607,47 +614,42 @@ def main(argv=None) -> int:
 
     # in order of expected run time, fast to slow
     # 1. static strings (done above)
+    #  a) includes language-specific strings, if applicable
     # 2. stack strings
     # 3. tight strings
     # 4. decoded strings
 
     if results.analysis.enable_static_strings:
+        logger.info("extracting static strings")
         results.strings.static_strings = static_strings
         results.metadata.runtime.static_strings = static_runtime
 
-        if not lang_id:
-            logger.info("extracting static strings")
-        else:
-            if lang_id == Language.GO:
-                logger.info("extracting language-specific Go strings")
+        if results.metadata.language == Language.GO.value:
+            logger.info("extracting language-specific Go strings")
 
-                interim = time()
-                results.strings.language_strings = floss.language.go.extract.extract_go_strings(sample, args.min_length)
-                results.metadata.runtime.language_strings = get_runtime_diff(interim)
+            interim = time()
+            results.strings.language_strings = floss.language.go.extract.extract_go_strings(sample, args.min_length)
+            results.metadata.runtime.language_strings = get_runtime_diff(interim)
 
-                # missed strings only includes non-identified strings in searched range
-                # here currently only focus on strings in string blob range
-                string_blob_strings = floss.language.go.extract.get_static_strings_from_blob_range(
-                    sample, static_strings
-                )
-                results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
-                    string_blob_strings, results.strings.language_strings, args.min_length
-                )
+            # missed strings only includes non-identified strings in searched range
+            # here currently only focus on strings in string blob range
+            string_blob_strings = floss.language.go.extract.get_static_strings_from_blob_range(sample, static_strings)
+            results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
+                string_blob_strings, results.strings.language_strings, args.min_length
+            )
 
-            elif lang_id == Language.RUST:
-                logger.info("extracting language-specific Rust strings")
+        elif results.metadata.language == Language.RUST.value:
+            logger.info("extracting language-specific Rust strings")
 
-                interim = time()
-                results.strings.language_strings = floss.language.rust.extract.extract_rust_strings(
-                    sample, args.min_length
-                )
-                results.metadata.runtime.language_strings = get_runtime_diff(interim)
+            interim = time()
+            results.strings.language_strings = floss.language.rust.extract.extract_rust_strings(sample, args.min_length)
+            results.metadata.runtime.language_strings = get_runtime_diff(interim)
 
-                # currently Rust strings are only extracted from the .rdata section
-                rdata_strings = floss.language.rust.extract.get_static_strings_from_rdata(sample, static_strings)
-                results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
-                    rdata_strings, results.strings.language_strings, args.min_length
-                )
+            # currently Rust strings are only extracted from the .rdata section
+            rdata_strings = floss.language.rust.extract.get_static_strings_from_rdata(sample, static_strings)
+            results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
+                rdata_strings, results.strings.language_strings, args.min_length
+            )
     if (
         results.analysis.enable_decoded_strings
         or results.analysis.enable_stack_strings

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -46,8 +46,19 @@ def width(s: str, character_count: int) -> str:
 
 def render_meta(results: ResultDocument, console, verbose):
     rows: List[Tuple[str, str]] = list()
+
+    lang = f"{results.metadata.language}" if results.metadata.language else ""
+    lang_v = (
+        f" ({results.metadata.language_version})"
+        if results.metadata.language != "unknown" and results.metadata.language_version
+        else ""
+    )
+    lang_s = f" - selected: {results.metadata.language_selected}" if results.metadata.language_selected else ""
+    language_value = f"{lang}{lang_v}{lang_s}"
+
     if verbose == Verbosity.DEFAULT:
         rows.append((width("file path", MIN_WIDTH_LEFT_COL), width(results.metadata.file_path, MIN_WIDTH_RIGHT_COL)))
+        rows.append(("identified language", language_value))
     else:
         rows.extend(
             [
@@ -55,7 +66,7 @@ def render_meta(results: ResultDocument, console, verbose):
                 ("start date", results.metadata.runtime.start_date.strftime("%Y-%m-%d %H:%M:%S")),
                 ("runtime", strtime(results.metadata.runtime.total)),
                 ("version", results.metadata.version),
-                ("identified language", results.metadata.language),
+                ("identified language", language_value),
                 ("imagebase", f"0x{results.metadata.imagebase:x}"),
                 ("min string length", f"{results.metadata.min_length}"),
             ]

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -145,7 +145,7 @@ def strtime(seconds):
 
 def render_language_strings(language, language_strings, language_strings_missed, console, verbose, disable_headers):
     strings = sorted(language_strings + language_strings_missed, key=lambda s: s.offset)
-    render_heading(f"FLOSS {language.upper()} STRINGS", len(strings), console, verbose, disable_headers)
+    render_heading(f"FLOSS {language.upper()} STRINGS ({len(strings)})", console, verbose, disable_headers)
     offset_len = len(f"{strings[-1].offset}")
     for s in strings:
         if verbose == Verbosity.DEFAULT:
@@ -153,7 +153,6 @@ def render_language_strings(language, language_strings, language_strings_missed,
         else:
             colored_string = string_style(sanitize(s.string, is_ascii_only=False))
             console.print(f"0x{s.offset:>0{offset_len}x} {colored_string}")
-    console.print("\n")
 
 
 def render_static_substrings(strings, encoding, offset_len, console, verbose, disable_headers):
@@ -166,11 +165,10 @@ def render_static_substrings(strings, encoding, offset_len, console, verbose, di
         else:
             colored_string = string_style(sanitize(s.string))
             console.print(f"0x{s.offset:>0{offset_len}x} {colored_string}")
-    console.print("\n")
 
 
 def render_staticstrings(strings, console, verbose, disable_headers):
-    render_heading("FLOSS STATIC STRINGS", len(strings), console, verbose, disable_headers)
+    render_heading(f"FLOSS STATIC STRINGS ({len(strings)})", console, verbose, disable_headers)
 
     ascii_strings = list(filter(lambda s: s.encoding == StringEncoding.ASCII, strings))
     unicode_strings = list(filter(lambda s: s.encoding == StringEncoding.UTF16LE, strings))
@@ -184,6 +182,7 @@ def render_staticstrings(strings, console, verbose, disable_headers):
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
     render_static_substrings(ascii_strings, "ASCII", offset_len, console, verbose, disable_headers)
+    console.print("\n")
     render_static_substrings(unicode_strings, "UTF-16LE", offset_len, console, verbose, disable_headers)
 
 
@@ -249,13 +248,13 @@ def render_decoded_strings(decoded_strings: List[DecodedString], console, verbos
                 console.print("\n")
 
 
-def render_heading(heading, n, console, verbose, disable_headers):
+def render_heading(heading, console, verbose, disable_headers):
     """
     example::
 
-        ===========================
-        ‖ FLOSS TIGHT STRINGS (0) ‖
-        ===========================
+         ─────────────────────────
+          FLOSS TIGHT STRINGS (0)
+         ─────────────────────────
     """
     if disable_headers:
         return
@@ -314,6 +313,10 @@ def render(results: floss.results.ResultDocument, verbose, disable_headers, colo
         render_meta(results, console, verbose)
         console.print("\n")
 
+    if results.analysis.enable_static_strings:
+        render_staticstrings(results.strings.static_strings, console, verbose, disable_headers)
+        console.print("\n")
+
     if results.metadata.language in (
         floss.language.identify.Language.GO.value,
         floss.language.identify.Language.RUST.value,
@@ -326,23 +329,22 @@ def render(results: floss.results.ResultDocument, verbose, disable_headers, colo
             verbose,
             disable_headers,
         )
-
-    elif results.analysis.enable_static_strings:
-        render_staticstrings(results.strings.static_strings, console, verbose, disable_headers)
         console.print("\n")
 
     if results.analysis.enable_stack_strings:
-        render_heading("FLOSS STACK STRINGS", len(results.strings.stack_strings), console, verbose, disable_headers)
+        render_heading(f"FLOSS STACK STRINGS ({len(results.strings.stack_strings)})", console, verbose, disable_headers)
         render_stackstrings(results.strings.stack_strings, console, verbose, disable_headers)
         console.print("\n")
 
     if results.analysis.enable_tight_strings:
-        render_heading("FLOSS TIGHT STRINGS", len(results.strings.tight_strings), console, verbose, disable_headers)
+        render_heading(f"FLOSS TIGHT STRINGS ({len(results.strings.tight_strings)})", console, verbose, disable_headers)
         render_stackstrings(results.strings.tight_strings, console, verbose, disable_headers)
         console.print("\n")
 
     if results.analysis.enable_decoded_strings:
-        render_heading("FLOSS DECODED STRINGS", len(results.strings.decoded_strings), console, verbose, disable_headers)
+        render_heading(
+            f"FLOSS DECODED STRINGS ({len(results.strings.decoded_strings)})", console, verbose, disable_headers
+        )
         render_decoded_strings(results.strings.decoded_strings, console, verbose, disable_headers)
 
     console.file.seek(0)

--- a/floss/results.py
+++ b/floss/results.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2021 Mandiant, Inc. All Rights Reserved.
 
+import re
 import json
 import datetime
 from enum import Enum
@@ -138,6 +139,9 @@ class StaticString:
             decoded_string = buf.decode("utf-8")
         except UnicodeDecodeError:
             raise ValueError("not utf-8")
+
+        if not re.sub(r"[\r\n\t]", "", decoded_string).isprintable():
+            raise ValueError("not printable")
 
         if len(decoded_string) < min_length:
             raise ValueError("too short")

--- a/floss/results.py
+++ b/floss/results.py
@@ -191,6 +191,8 @@ class Metadata:
     min_length: int = 0
     runtime: Runtime = field(default_factory=Runtime)
     language: str = ""
+    language_version: str = ""
+    language_selected: str = ""  # configured by user
 
 
 @dataclass

--- a/tests/test_language_id.py
+++ b/tests/test_language_id.py
@@ -1,30 +1,30 @@
-import os
 from pathlib import Path
 
 import pytest
 
 from floss.utils import get_static_strings
-from floss.language.identify import Language, identify_language
+from floss.language.identify import VERSION_UNKNOWN_OR_NA, Language, identify_language_and_version
 
 
 @pytest.mark.parametrize(
-    "binary_file, expected_result",
+    "binary_file, expected_result, expected_version",
     [
-        ("data/language/go/go-hello/bin/go-hello.exe", Language.GO),
-        ("data/language/rust/rust-hello/bin/rust-hello.exe", Language.RUST),
-        ("data/test-decode-to-stack.exe", Language.UNKNOWN),
-        ("data/language/dotnet/dotnet-hello/bin/dotnet-hello.exe", Language.DOTNET),
-        ("data/src/shellcode-stackstrings/bin/shellcode-stackstrings.bin", Language.UNKNOWN),
+        ("data/language/go/go-hello/bin/go-hello.exe", Language.GO, "1.20"),
+        ("data/language/rust/rust-hello/bin/rust-hello.exe", Language.RUST, "1.69.0"),
+        ("data/test-decode-to-stack.exe", Language.UNKNOWN, VERSION_UNKNOWN_OR_NA),
+        ("data/language/dotnet/dotnet-hello/bin/dotnet-hello.exe", Language.DOTNET, VERSION_UNKNOWN_OR_NA),
+        ("data/src/shellcode-stackstrings/bin/shellcode-stackstrings.bin", Language.UNKNOWN, VERSION_UNKNOWN_OR_NA),
     ],
 )
-def test_language_detection(binary_file, expected_result):
+def test_language_detection(binary_file, expected_result, expected_version):
     CD = Path(__file__).resolve().parent
     abs_path = (CD / binary_file).resolve()
-    # check if the file exists
+
     assert abs_path.exists(), f"File {binary_file} does not exist"
 
     static_strings = get_static_strings(abs_path, 4)
 
-    language = identify_language(abs_path, static_strings)
-    # Check the expected result
+    language, version = identify_language_and_version(abs_path, static_strings)
+
     assert language == expected_result, f"Expected: {expected_result.value}, Actual: {language.value}"
+    assert version == expected_version, f"Expected: {expected_version}, Actual: {version}"


### PR DESCRIPTION
Various fixes including to update `language_strings_missed` to only include strings from the range (e.g. `.rdata` section for Rust or the strings blob in Go) that may have been missed during extraction.

This renders language strings separately from static strings. Language strings are part of static strings and it's currently not possible to display them individually. This can be added later, if desired.

closes #875
closes #900