### PR TITLE
Fix: Handle default prompt when stdout is redirected

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -598,12 +598,11 @@ def main(argv=None) -> int:
 
     if results.metadata.language not in ("", "unknown"):
         if args.enabled_types == [] and args.disabled_types == []:
-
-            # when stdout is redirected, such as in 'floss foo.exe | less' use default prompt values 
+            # when stdout is redirected, such as in 'floss foo.exe | less' use default prompt values
             if sys.stdout.isatty():
                 prompt = input("Do you want to enable string deobfuscation? (this could take a long time) [y/N] ")
             else:
-                prompt = "n"            
+                prompt = "n"
 
             if prompt.lower() == "y":
                 logger.info("enabled string deobfuscation")

--- a/floss/main.py
+++ b/floss/main.py
@@ -598,7 +598,12 @@ def main(argv=None) -> int:
 
     if results.metadata.language not in ("", "unknown"):
         if args.enabled_types == [] and args.disabled_types == []:
-            prompt = input("Do you want to enable string deobfuscation? (this could take a long time) [y/N] ")
+            
+            # if floss foo.exe | less is used, we don't want to prompt the user
+            if sys.stdout.isatty():
+                prompt = input("Do you want to enable string deobfuscation? (this could take a long time) [y/N] ")
+            else:
+                prompt = "n"            
 
             if prompt.lower() == "y":
                 logger.info("enabled string deobfuscation")

--- a/floss/main.py
+++ b/floss/main.py
@@ -598,8 +598,8 @@ def main(argv=None) -> int:
 
     if results.metadata.language not in ("", "unknown"):
         if args.enabled_types == [] and args.disabled_types == []:
-            
-            # if floss foo.exe | less is used, we don't want to prompt the user
+
+            # when stdout is redirected, such as in 'floss foo.exe | less' use default prompt values 
             if sys.stdout.isatty():
                 prompt = input("Do you want to enable string deobfuscation? (this could take a long time) [y/N] ")
             else:


### PR DESCRIPTION
Fixes #930 - Use default prompt answer ("N"), when using ```floss foo.exe | less```.