### PR TITLE
Identify XOR Encoded PE files

### DIFF
--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -1090,7 +1090,7 @@ def render_strings(
 
     name = layout.name
     if isinstance(layout, PELayout) and layout.xor_key:  # Check if the layout is PELayout and is xored
-        name += f" (XOR decoded with key: {layout.xor_key})"
+        name += f" (XOR decoded with key: 0x{layout.xor_key:x})"
     if name_hint:
         name = f"{name_hint} ({name})"
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setuptools.setup(
             "dnfile==0.13.0",
             "colorama==0.4.6",
             "msgspec==0.14.2",
-            "python-lancelot==0.8.8",
+            "python-lancelot==0.8.7",
         ],
         "dev": [
             "pyyaml==6.0",


### PR DESCRIPTION
Closes #757 

Taking reference from how capa identifies xor encodeded [[features/extractors/helper.py](https://github.com/mandiant/capa/blob/master/capa/features/extractors/helpers.py)]


<img width="1109" alt="image" src="https://github.com/mandiant/flare-floss/assets/89736193/79ad0b7b-7dd1-4070-93c3-ce2a10dedf79">

<img width="1100" alt="image" src="https://github.com/mandiant/flare-floss/assets/89736193/f8fe66e0-0f7e-4862-abbc-4708f3753f6c">
