### PR TITLE
Provide an option to install right click menu option for Windows

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -77,6 +77,9 @@ This means that Python will load the FLOSS module from this local
 This is good, because it is easy for us to modify files and see the
  effects reflected immediately.
 But be careful not to remove this directory unless uninstalling FLOSS!
+If you encounter the error `ERROR: Project has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook.`,
+ please ensure that you have upgraded to the latest versions of pip and setuptools.
+
 
 - Install FLOSS:
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -140,6 +140,16 @@ Specify functions by using their hex-encoded virtual address.
     floss.exe --functions 0x401000 0x402000 malware.exe
 
 
+### Install/Uninstall right click menu option for Windows (`--install-right-click-menu/--uninstall-right-click-menu`)
+
+You can use the `--install-right-click-menu` and `--uninstall-right-click-menu` 
+ options to install/remove the `Open with FLOSS` option from the right-click menu 
+ of the Windows file explorer.
+
+After this option is installed, you can right-click on any file and select `Open with FLOSS`
+ to quickly open the target file with FLOSS for analysis.
+
+
 ## <a name="shellcode"></a>Shellcode analysis options
 
 Malicious shellcode often times contains obfuscated strings or stackstrings.

--- a/floss/main.py
+++ b/floss/main.py
@@ -257,13 +257,21 @@ def make_parser(argv):
         advanced_group.add_argument(
             "--install-right-click-menu",
             action=floss.utils.InstallContextMenu,
-            help="install FLOSS to the right-click context menu for Windows Explorer and exit",
+            help=(
+                "install FLOSS to the right-click context menu for Windows Explorer and exit"
+                if show_all_options
+                else argparse.SUPPRESS
+            ),
         )
 
         advanced_group.add_argument(
             "--uninstall-right-click-menu",
             action=floss.utils.UninstallContextMenu,
-            help="uninstall FLOSS from the right-click context menu for Windows Explorer and exit",
+            help=(
+                "uninstall FLOSS from the right-click context menu for Windows Explorer and exit"
+                if show_all_options
+                else argparse.SUPPRESS
+            ),
         )
 
     output_group = parser.add_argument_group("rendering arguments")

--- a/floss/main.py
+++ b/floss/main.py
@@ -10,7 +10,6 @@ from enum import Enum
 from time import time
 from typing import Set, List, Optional
 from pathlib import Path
-import platform
 
 import halo
 import viv_utils
@@ -145,20 +144,6 @@ def make_parser(argv):
     )
     parser.register("action", "extend", floss.utils.ExtendAction)
     parser.add_argument("-H", action="help", help="show advanced options and exit")
-    
-    if platform.system() == "Windows":
-        parser.add_argument(
-            "--install-right-click-menu",
-            action=floss.utils.InstallContextMenu,
-            help="install FLOSS to the right-click context menu for Windows Explorer and exit"
-        )
-
-        parser.add_argument(
-            "--uninstall-right-click-menu",
-            action=floss.utils.UninstallContextMenu,
-            help="uninstall FLOSS from the right-click context menu for Windows Explorer and exit"
-        )
-
     parser.add_argument(
         "-n",
         "--minimum-length",
@@ -268,6 +253,18 @@ def make_parser(argv):
         version="%(prog)s {:s}".format(__version__),
         help="show program's version number and exit" if show_all_options else argparse.SUPPRESS,
     )
+    if sys.platform == "win32":
+        advanced_group.add_argument(
+            "--install-right-click-menu",
+            action=floss.utils.InstallContextMenu,
+            help="install FLOSS to the right-click context menu for Windows Explorer and exit",
+        )
+
+        advanced_group.add_argument(
+            "--uninstall-right-click-menu",
+            action=floss.utils.UninstallContextMenu,
+            help="uninstall FLOSS from the right-click context menu for Windows Explorer and exit",
+        )
 
     output_group = parser.add_argument_group("rendering arguments")
     output_group.add_argument("-j", "--json", action="store_true", help="emit JSON instead of text")

--- a/floss/main.py
+++ b/floss/main.py
@@ -10,6 +10,7 @@ from enum import Enum
 from time import time
 from typing import Set, List, Optional
 from pathlib import Path
+import platform
 
 import halo
 import viv_utils
@@ -144,6 +145,19 @@ def make_parser(argv):
     )
     parser.register("action", "extend", floss.utils.ExtendAction)
     parser.add_argument("-H", action="help", help="show advanced options and exit")
+    
+    if platform.system() == "Windows":
+        parser.add_argument(
+            "--install-right-click-menu",
+            action=floss.utils.InstallContextMenu,
+            help="install FLOSS to the right-click context menu for Windows Explorer and exit"
+        )
+
+        parser.add_argument(
+            "--uninstall-right-click-menu",
+            action=floss.utils.UninstallContextMenu,
+            help="uninstall FLOSS from the right-click context menu for Windows Explorer and exit"
+        )
 
     parser.add_argument(
         "-n",


### PR DESCRIPTION
This implements #745.

Implemented two options for installing and uninstalling the Windows context menu and tested them on Windows.

By the way, I've also added a hint to upgrade pip and setuptools in the documentation (PEP660 has only been implemented in newer versions of setuptools)