### PR TITLE
add content-type MD for readme declaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dynamic = ["version", "readme"]
 
 [tool.setuptools.dynamic]
 version = {attr = "floss.version.__version__"}
-readme = {file = "README.md"}
+readme = {file = "README.md", content-type = "text/markdown"}
 
 [tool.setuptools]
 packages = ["floss", "floss.sigs"]


### PR DESCRIPTION
may fix publish package error:

```
Checking dist/flare_floss-3.1.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 39: Error: Unexpected indentation.                                
Checking dist/flare_floss-3.1.0.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 39: Error: Unexpected indentation. 
```