### PR TITLE
Add verbose output of file offsets and virtual addresses for language-specific strings

### DIFF
--- a/floss/language/rust/extract.py
+++ b/floss/language/rust/extract.py
@@ -135,6 +135,23 @@ def get_static_strings_from_rdata(sample, static_strings) -> List[StaticString]:
     return list(filter(lambda s: start_rdata <= s.offset < end_rdata, static_strings))
 
 
+def get_file_offset_in_rdata(sample: pathlib.Path) -> int:
+    pe = pefile.PE(data=pathlib.Path(sample).read_bytes(), fast_load=True)
+
+    try:
+        rdata_section = get_rdata_section(pe)
+    except ValueError:
+        return -1
+
+    image_base = pe.OPTIONAL_HEADER.ImageBase
+    virtual_address = rdata_section.VirtualAddress
+    pointer_to_raw_data = rdata_section.PointerToRawData
+
+    print("DD:", image_base + virtual_address - pointer_to_raw_data)
+
+    return image_base + virtual_address - pointer_to_raw_data
+
+
 def get_string_blob_strings(pe: pefile.PE, min_length: int) -> Iterable[StaticString]:
     image_base = pe.OPTIONAL_HEADER.ImageBase
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -681,6 +681,11 @@ def main(argv=None) -> int:
             results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
                 rdata_strings, results.strings.language_strings, args.min_length
             )
+
+            # get the file offset diff file offset and va 
+            if args.verbose:
+                results.metadata.file_offset_in_rdata = floss.language.rust.extract.get_file_offset_in_rdata(sample)
+
     if (
         results.analysis.enable_decoded_strings
         or results.analysis.enable_stack_strings

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -158,7 +158,7 @@ def strtime(seconds):
     return f"{m:02.0f}:{s:02.0f}"
 
 
-def render_language_strings(language, language_strings, language_strings_missed, console, verbose, disable_headers):
+def render_language_strings(language, language_strings, language_strings_missed, file_offset, console, verbose, disable_headers):
     strings = sorted(language_strings + language_strings_missed, key=lambda s: s.offset)
     render_heading(f"FLOSS {language.upper()} STRINGS ({len(strings)})", console, verbose, disable_headers)
     offset_len = len(f"{strings[-1].offset}")
@@ -167,7 +167,7 @@ def render_language_strings(language, language_strings, language_strings_missed,
             console.print(sanitize(s.string, is_ascii_only=False), markup=False)
         else:
             colored_string = string_style(sanitize(s.string, is_ascii_only=False))
-            console.print(f"0x{s.offset:>0{offset_len}x} {colored_string}")
+            console.print(f"0x{s.offset:>0{offset_len}x} 0x{s.offset + file_offset:>0{offset_len}x} {colored_string}")
 
 
 def render_static_substrings(strings, encoding, offset_len, console, verbose, disable_headers):
@@ -340,9 +340,10 @@ def render(results: floss.results.ResultDocument, verbose, disable_headers, colo
             results.metadata.language,
             results.strings.language_strings,
             results.strings.language_strings_missed,
+            results.metadata.file_offset_in_rdata,
             console,
             verbose,
-            disable_headers,
+            disable_headers
         )
         console.print("\n")
 

--- a/floss/results.py
+++ b/floss/results.py
@@ -4,7 +4,7 @@ import re
 import json
 import datetime
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 from pathlib import Path
 from dataclasses import field
 
@@ -194,6 +194,7 @@ class Metadata:
     language: str = ""
     language_version: str = ""
     language_selected: str = ""  # configured by user
+    file_offset_in_rdata: Optional[int] = None
 
 
 @dataclass


### PR DESCRIPTION
This PR enhances the verbose output to display raw file offsets and virtual addresses for Rust strings.

Fixes: #925 #937

*The PR is in draft status because it currently only supports Rust strings.

![image](https://github.com/mandiant/flare-floss/assets/94680887/34f02473-8ed7-41c6-9da9-2db8a96e7773)
