### PR TITLE
release v3.1.1

### DIFF
--- a/floss/version.py
+++ b/floss/version.py
@@ -1,3 +1,3 @@
 # Copyright (C) 2017 Mandiant, Inc. All Rights Reserved.
 # caution: this file gets overwritten when building using PyInstaller, don't add required data in here without handling
-__version__ = "3.1.0"
+__version__ = "3.1.1"


### PR DESCRIPTION
# Release Notes

This small release relaxes restrictions on dependencies, which enables you to use FLOSS with Python 3.12 and newer (closes #1043).

## Changes

* relax pyproject dependency versions and introduce requirements.txt by @williballenthin in https://github.com/mandiant/flare-floss/pull/1012

**Full Changelog**: https://github.com/mandiant/flare-floss/compare/v3.1.0...v3.1.1