### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/floss/decoding_manager.py
+++ b/floss/decoding_manager.py
@@ -171,7 +171,7 @@ def emulate_function(
     try:
         pre_snap = make_snapshot(emu)
     except MapsTooLargeError:
-        logger.warn("initial snapshot mapped too much memory, can't extract strings")
+        logger.warning("initial snapshot mapped too much memory, can't extract strings")
         return []
 
     delta_collector = DeltaCollectorHook(pre_snap)


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```