### PR TITLE
Remove transitive dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dependencies = [
     # latest bug fixes we need here.
     "viv-utils[flirt]>=0.7.9",
     "vivisect>=1.1.1",
-    "dncil>=1.0.2",
 
     # ---------------------------------------
     # Dependencies with version caps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,15 @@
-annotated-types==0.7.0
 binary2strings==0.1.13
 black==25.1.0
 cfgv==3.4.0
 click==8.2.1
-colorama==0.4.6
 coverage==7.9.2
-cxxfilt==0.3.0
 distlib==0.3.8
-dncil==1.0.2
 filelock==3.18.0
-funcy==2.0
 halo==0.0.31
 identify==2.6.1
 iniconfig==2.0.0
 intervaltree==3.1.0
 isort==6.0.1
-log-symbols==0.0.14
-markdown-it-py==3.0.0
-mdurl==0.1.2
-msgpack==1.0.8
 mypy==1.16.1
 networkx==3.4.2
 nodeenv==1.9.1
@@ -30,9 +21,7 @@ platformdirs==4.3.6
 pluggy==1.5.0
 pre-commit==4.2.0
 pyasn1==0.5.1
-pyasn1-modules==0.3.0
 pycodestyle==2.13.0
-pycparser==2.22
 pydantic==2.10.1
 # pydantic pins pydantic-core, 
 # but dependabot updates these separately (which is broken) and is annoying,
@@ -43,15 +32,11 @@ pytest==8.4.1
 pytest-cov==6.2.1
 pytest-instafail==0.5.0
 pytest-sugar==1.0.0
-python-flirt==0.9.2
 pyyaml==6.0.1
 rich==13.9.2
 setuptools==80.9.0
-six==1.17.0
 sortedcontainers==2.4.0
-spinners==0.0.24
 tabulate==0.9.0
-termcolor==3.1.0
 tqdm==4.67.1
 types-pyyaml==6.0.10
 types-tabulate==0.9.0.20240106


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we noticed a potential improvement in your project’s declared dependencies.

Specifically, several dependencies appear to be  transitive, meaning they are already required by top-level packages and do not need to be listed explicitly.

The following dependencies were removed from the configuration files after verifying they are not directly used:

`msgpack` `annotated-types` `termcolor` `markdown-it-py` `dncil` `spinners` `python-flirt` `pyasn1-modules` `six` `cxxfilt` `pycparser` `funcy` `log-symbols` `colorama` `mdurl`

Removing these helps keep the dependency list clean and maintainable. It also allows pip’s resolver to handle transitive requirements more efficiently.

The [pip documentation](https://pip.pypa.io/en/stable/user_guide/#requirements-files) also encourages auditing your top-level requirements and removing unused or transitive ones to simplify the dependency graph and minimize the risk of version conflicts.