### PR TITLE
Add Go decoded stackstring extraction via runtime.slicebytetostring callsites

### DIFF
--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -20,17 +20,19 @@ import struct
 import logging
 import pathlib
 import argparse
-from typing import List, Tuple, Iterable, Optional
+from typing import Dict, List, Tuple, Iterable, Optional
 from pathlib import Path
 from itertools import chain
 from dataclasses import dataclass
 
 import pefile
+import vivisect.const
 from typing_extensions import TypeAlias
 
 import floss.utils
 from floss.results import StaticString, StringEncoding
 from floss.language.utils import StructString, find_lea_xrefs, get_struct_string_candidates
+from floss.language.go.pclntab import find_runtime_functions
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +424,92 @@ def get_static_strings_from_blob_range(sample: pathlib.Path, static_strings: Lis
     string_blob_end = pe.get_offset_from_rva(string_blob_end - image_base)
 
     return list(filter(lambda s: string_blob_start <= s.offset < string_blob_end, static_strings))
+
+
+def find_slicebytetostring_callsites(vw, pe: Optional[pefile.PE] = None) -> Dict[int, List[int]]:
+    """
+    Locate all call sites to runtime.slicebytetostring within the vivisect workspace vw
+    Returns {callee_va: [caller_va, ...]}
+
+    Strategy
+    1. vivisect name table fast path that works for non-stripped binaries
+       where the Go toolchain embeds symbol names into the ELF/PE symbol table
+    2. pclntab resolver fallback for stripped/garble/gobfuscate binaries
+       pclntab is a runtime data structure that survives stripping, we parse it
+       directly from pe(or from vw.getFiles()[0] when pe is not given)
+       to build a name -> VA map and then look up xrefs in the vivisect workspace
+
+    The two approaches are complementary: step 1 is O(names) + fast; step 2
+    handles the obfuscated case that is the whole motivation for this work
+    """
+    _SLICEBYTETOSTRING_TOKENS = (
+        "runtime.slicebytetostring",
+        "runtime_slicebytetostring",
+        "slicebytetostring",
+    )
+
+    def _xrefs_to(callee_va: int) -> List[int]:
+        try:
+            xrefs = vw.getXrefsTo(callee_va, rtype=vivisect.const.REF_CODE)
+            return sorted({xr[0] for xr in xrefs})
+        except Exception:
+            return []
+
+    out: Dict[int, List[int]] = {}
+
+    ## step 1 vivisect name table (works for non-stripped binaries)
+    try:
+        names = vw.getNames()
+        items = names.items() if hasattr(names, "items") else names
+        for va, name in items:
+            lname = str(name).lower()
+            if any(tok in lname for tok in _SLICEBYTETOSTRING_TOKENS):
+                callers = _xrefs_to(va)
+                if callers:
+                    out[va] = callers
+    except Exception as exc:
+        logger.debug("vw.getNames() failed: %s", exc)
+
+    if out:
+        logger.debug(
+            "slicebytetostring: found %d callee(s) via vivisect names (%d total callsites)",
+            len(out),
+            sum(len(v) for v in out.values()),
+        )
+        return out
+
+    ## step 2 pclntab resolver (fallback for stripped/obfuscated binarie)
+    logger.debug("slicebytetostring: vivisect name table empty, falling back to pclntab scan")
+
+    try:
+        _pe = pe
+        if _pe is None:
+            # Derive PE path from the vivisect workspace file list
+            files = vw.getFiles()
+            if not files:
+                logger.debug("vw.getFiles() returned nothing, cannot open PE for pclntab scan")
+                return out
+            sample_path = files[0]
+            _pe = pefile.PE(sample_path, fast_load=True)
+
+        hits = find_runtime_functions(_pe, _SLICEBYTETOSTRING_TOKENS)
+        for name, callee_va in hits.items():
+            callers = _xrefs_to(callee_va)
+            if callers:
+                out[callee_va] = callers
+                logger.debug("pclntab: %s at 0x%x -> %d callsite(s)", name, callee_va, len(callers))
+            else:
+                logger.debug("pclntab: %s at 0x%x (no code xrefs found)", name, callee_va)
+
+    except Exception as exc:
+        logger.debug("pclntab resolver failed: %s", exc, exc_info=True)
+
+    logger.debug(
+        "slicebytetostring: pclntab found %d callee(s) (%d total callsites)",
+        len(out),
+        sum(len(v) for v in out.values()),
+    )
+    return out
 
 
 def main(argv=None):

--- a/floss/language/go/pclntab.py
+++ b/floss/language/go/pclntab.py
@@ -1,0 +1,382 @@
+"""
+Go pclntab parser
+
+Extracts a { function_name -> virtual_address } mapping from Go PE binaries
+for all pclntab versions: 1.2 (covers 1.2-1.15), 1.16, 1.18, 1.20
+
+This works on stripped and obfuscated binaries (garble / gobfuscate) because
+pclntab is a runtime data structure that must survive stripping; only the ELF/PE
+*section name* may be erased, which we handle via magic-byte scanning
+
+References used:
+- Go pclntab spec        : https://docs.google.com/document/d/1lyPIbmsYbXnpNj57a261hgOYVpNRcgydurVQIyZOz_o/pub
+- Go upstream source     : https://go.dev/src/debug/gosym/pclntab.go
+- GoReSym                : https://github.com/mandiant/GoReSym
+- golang_pclntab_parser  : https://github.com/dipusone/golang_pclntab_parser
+"""
+
+import struct
+import logging
+from typing import Dict, List, Tuple, Optional
+
+import pefile
+
+logger = logging.getLogger(__name__)
+
+### pclntab magic bytes (first 6 bytes of table)
+# Go 1.2 – 1.15
+MAGIC_V12 = b"\xfb\xff\xff\xff\x00\x00"
+# Go 1.16 – 1.17
+MAGIC_V116 = b"\xfa\xff\xff\xff\x00\x00"
+# Go 1.18 – 1.19
+MAGIC_V118 = b"\xf0\xff\xff\xff\x00\x00"
+# Go 1.20+
+MAGIC_V120 = b"\xf1\xff\xff\xff\x00\x00"
+
+# Ordered most-recent-first so we match the likeliest binary first during scan
+ALL_MAGICS: Tuple[bytes, ...] = (MAGIC_V120, MAGIC_V118, MAGIC_V116, MAGIC_V12)
+
+# Valid values for quantum (byte 6) and ptrsize (byte 7) in the header
+_VALID_QUANTUM = frozenset((1, 2, 4))
+_VALID_PTRSIZE = frozenset((4, 8))
+
+
+### Public API
+
+
+def parse_pclntab(pe: pefile.PE) -> Dict[str, int]:
+    """
+    Parse pclntab from pe and return a {function_name: start_va} mapping
+
+    Works on:
+    - normal (non-stripped) PE with .gopclntab section
+    - stripped PE (magic-byte scan across all sections)
+    - garble / gobfuscate binaries (pclntab data survives, section name is gone)
+    """
+    try:
+        pclntab_va, data = _locate_pclntab(pe)
+    except ValueError as exc:
+        logger.debug("pclntab not found: %s", exc)
+        # empty return
+        return {}
+
+    if len(data) < 8:
+        logger.debug("pclntab too short (%d bytes)", len(data))
+        return {}
+
+    magic = data[:6]
+    quantum = data[6]
+    ptrsize = data[7]
+
+    if quantum not in _VALID_QUANTUM or ptrsize not in _VALID_PTRSIZE:
+        logger.debug("invalid pclntab header: quantum=%d ptrsize=%d", quantum, ptrsize)
+        return {}
+
+    version = _magic_to_version(magic)
+    logger.debug("pclntab at VA=0x%x  version=%s  ptrsize=%d", pclntab_va, version, ptrsize)
+
+    try:
+        if version == "1.2":
+            return _parse_v12(data, ptrsize)
+        elif version == "1.16":
+            return _parse_v116(data, ptrsize)
+        elif version in ("1.18", "1.20"):
+            return _parse_v118(data, ptrsize)
+        else:
+            logger.debug("unsupported pclntab version: %s", version)
+            return {}
+    except Exception as exc:
+        logger.debug("error parsing pclntab: %s", exc, exc_info=True)
+        return {}
+
+
+def find_runtime_functions(pe: pefile.PE, name_tokens) -> Dict[str, int]:
+    """
+    Return {name: va} for all pclntab functions whose name contains any of
+    the case-insensitive name_tokens (e.g "slicebytetostring")
+    """
+    all_funcs = parse_pclntab(pe)
+    lower_tokens = tuple(t.lower() for t in name_tokens)
+    result = {}
+    for name, va in all_funcs.items():
+        if any(tok in name.lower() for tok in lower_tokens):
+            result[name] = va
+    return result
+
+
+### pclntab location
+
+
+def _locate_pclntab(pe: pefile.PE) -> Tuple[int, bytes]:
+    """
+    Locate pclntab data inside pe
+
+    Strategy:
+    1. named section .gopclntab/gopclntab
+    2. magic byte scan across all sections, most-recent magic first
+
+    Returns (pclntab_va, bytes_starting_at_pclntab)
+    """
+    # 1)named section (non-obfuscated binary)
+    for section in pe.sections:
+        sec_name = section.Name.rstrip(b"\x00").decode("ascii", errors="replace")
+        if sec_name in (".gopclntab", "gopclntab"):
+            va = pe.OPTIONAL_HEADER.ImageBase + section.VirtualAddress
+            data = section.get_data()
+            if data and data[:6] in ALL_MAGICS:
+                logger.debug("found pclntab via section name '%s'", sec_name)
+                return va, data
+
+    # 2)magicbyte scan (stripped / obfuscated binary)
+    for magic in ALL_MAGICS:
+        for section in pe.sections:
+            sec_data = section.get_data()
+            idx = sec_data.find(magic)
+            if idx == -1:
+                continue
+            # quantum and ptrsize must be valid
+            if len(sec_data) <= idx + 7:
+                continue
+            quantum = sec_data[idx + 6]
+            ptrsize = sec_data[idx + 7]
+            if quantum in _VALID_QUANTUM and ptrsize in _VALID_PTRSIZE:
+                va = pe.OPTIONAL_HEADER.ImageBase + section.VirtualAddress + idx
+                logger.debug("found pclntab via magic scan at VA=0x%x", va)
+                return va, sec_data[idx:]
+
+    raise ValueError("pclntab not found in any PE section")
+
+
+### header helpers
+
+
+def _magic_to_version(magic):
+    return {
+        MAGIC_V12: "1.2",
+        MAGIC_V116: "1.16",
+        MAGIC_V118: "1.18",
+        MAGIC_V120: "1.20",
+    }.get(magic, "unknown")
+
+
+def _u32(data, offset):
+    return struct.unpack_from("<I", data, offset)[0]
+
+
+def _uptr(data, offset, ptrsize):
+    fmt = "<I" if ptrsize == 4 else "<Q"
+    return struct.unpack_from(fmt, data, offset)[0]
+
+
+def _cstring(data, offset):
+    """Read nullterminated UTF-8 string from data at offset"""
+    if offset >= len(data):
+        return None
+    end = data.find(b"\x00", offset)
+    if end == -1:
+        return None
+    try:
+        return data[offset:end].decode("utf-8", errors="replace") or None
+    except Exception:
+        return None
+
+
+### Version-specific parsers
+
+
+def _parse_v12(data, ptrsize) -> Dict[str, int]:
+    """
+    Parse Go 1.2 1.15 pclntab
+
+    Layout after the 8-byte header:
+        nfunctab : uint(ptrsize)
+        functab  : nfunctab * 2 * ptrsize   [(va, offset_in_pclntab), ...]
+        sentinel : 1 * 2 * ptrsize
+        fileoff  : uint32
+        filetab  : ...
+
+    Each funcc struct at pclntab[offset]:
+        entry   : uintptr
+        nameoff : int32     offset into whole pclntab for null-term name
+        ...
+    """
+    if len(data) < 8 + ptrsize:
+        return {}
+
+    nfunctab = _uptr(data, 8, ptrsize)
+    if nfunctab == 0 or nfunctab > 1_000_000:
+        logger.debug("v12: suspicious nfunctab=%d", nfunctab)
+        return {}
+
+    functab_start = 8 + ptrsize  # right after nfunctab
+    entry_size = 2 * ptrsize  # (va, offset)
+
+    funcs: Dict[str, int] = {}
+
+    for i in range(nfunctab):
+        base = functab_start + i * entry_size
+        if base + entry_size > len(data):
+            break
+
+        func_va = _uptr(data, base, ptrsize)
+        funcdata_off = _uptr(data, base + ptrsize, ptrsize)
+
+        # Func struct: [entry:ptrsize][nameoff:uint32]
+        nameoff_pos = funcdata_off + ptrsize
+        if nameoff_pos + 4 > len(data):
+            continue
+
+        nameoff = _u32(data, nameoff_pos)
+        name = _cstring(data, nameoff)  # nameoff is into whole pclntab for v12
+        if name:
+            funcs[name] = func_va
+
+    logger.debug("v12: extracted %d functions", len(funcs))
+    return funcs
+
+
+def _parse_v116(data: bytes, ptrsize: int) -> Dict[str, int]:
+    """
+    Parse Go 1.16 1.17 pclntab.
+
+    pcHeader layout after the 8-byte magic/quantum/ptrsize bytes:
+        nfunctab        : int   (ptrsize bytes)
+        nfiletab        : uint  (ptrsize bytes)
+        funcnameOffset  : uintptr   offset from pclntab[0] to funcnametab
+        cuOffset        : uintptr
+        filetabOffset   : uintptr
+        pctabOffset     : uintptr
+        pclnOffset      : uintptr   offset from pclntab[0] to functab/funcdata
+
+    functab entries (at pclntab[pclnOffset]):
+        va              : uintptr
+        funcdata_off    : uintptr offset within funcdata region
+
+    Func struct at funcdata[funcdata_off]:
+        entry  : uintptr
+        nameoff: uint32  offset into funcnametab
+    """
+    # Minimum header: 8 + 7 * ptrsize
+    if len(data) < 8 + 7 * ptrsize:
+        return {}
+
+    nfunctab = _uptr(data, 8, ptrsize)
+    if nfunctab == 0 or nfunctab > 1_000_000:
+        logger.debug("v116: suspicious nfunctab=%d", nfunctab)
+        return {}
+
+    # Section offsets (all relative to pclntab start)
+    # index: 0=nfunc 1=nfile 2=funcname 3=cu 4=filetab 5=pctab 6=pcln(functab)
+    funcname_off = _uptr(data, 8 + 2 * ptrsize, ptrsize)
+    pcln_off = _uptr(data, 8 + 6 * ptrsize, ptrsize)  # start of functab/funcdata
+
+    if funcname_off >= len(data) or pcln_off >= len(data):
+        return {}
+
+    ffs = ptrsize  # functab field size for 1.16
+    entry_size = 2 * ffs
+    functabsize = (nfunctab * 2 + 1) * ffs  # includes sentinel
+
+    funcdata = data[pcln_off:]
+    functab = funcdata[:functabsize]
+    funcnametab = data[funcname_off:]
+
+    funcs: Dict[str, int] = {}
+
+    for i in range(nfunctab):
+        base = i * entry_size
+        if base + entry_size > len(functab):
+            break
+
+        func_va = _uptr(functab, base, ffs)
+        funcdata_rel = _uptr(functab, base + ffs, ffs)  # offset within funcdata
+
+        # Func struct: [entry:ptrsize][nameoff:uint32]
+        nameoff_pos = funcdata_rel + ptrsize
+        if nameoff_pos + 4 > len(funcdata):
+            continue
+
+        nameoff = _u32(funcdata, nameoff_pos)
+        name = _cstring(funcnametab, nameoff)
+        if name:
+            funcs[name] = func_va
+
+    logger.debug("v116: extracted %d functions", len(funcs))
+    return funcs
+
+
+def _parse_v118(data: bytes, ptrsize: int) -> Dict[str, int]:
+    """
+    Parse Go 1.18 1.20+ pclntab.
+
+    Go 1.18 adds a textStart field to pcHeader and changes functab entries
+    from pointer-sized to uint32; PC values become textStart + uint32_offset
+
+    pcHeader layout after the 8-byte magic/quantum/ptrsize bytes:
+        nfunctab        : uint  (ptrsize bytes)
+        nfiletab        : uint  (ptrsize bytes)
+        textStart       : uintptr  base VA for PC offsets
+        funcnameOffset  : uintptr
+        cuOffset        : uintptr
+        filetabOffset   : uintptr
+        pctabOffset     : uintptr
+        pclnOffset      : uintptr  offset from pclntab[0] to functab/funcdata
+
+    functab entries (at pclntab[pclnOffset]) all uint32:
+        pc_off      : uint32   <- func_va = textStart + pc_off
+        funcdata_off: uint32   <- offset within funcdata region
+
+    Func struct at funcdata[funcdata_off]:
+        entry  : uint32
+        nameoff: uint32 offset into funcnametab
+    """
+    # Minimum header: 8 + 8 * ptrsize
+    if len(data) < 8 + 8 * ptrsize:
+        return {}
+
+    nfunctab = _uptr(data, 8, ptrsize)
+    text_start = _uptr(data, 8 + 2 * ptrsize, ptrsize)
+
+    if nfunctab == 0 or nfunctab > 1_000_000:
+        logger.debug("v118: suspicious nfunctab=%d", nfunctab)
+        return {}
+
+    # index: 0=nfunc 1=nfile 2=textStart 3=funcname 4=cu 5=filetab 6=pctab 7=pcln(functab)
+    funcname_off = _uptr(data, 8 + 3 * ptrsize, ptrsize)
+    pcln_off = _uptr(data, 8 + 7 * ptrsize, ptrsize)
+
+    if funcname_off >= len(data) or pcln_off >= len(data):
+        return {}
+
+    ffs = 4  # uint32 for 1.18+
+    entry_size = 2 * ffs
+    functabsize = (nfunctab * 2 + 1) * ffs
+
+    funcdata = data[pcln_off:]
+    functab = funcdata[:functabsize]
+    funcnametab = data[funcname_off:]
+
+    funcs: Dict[str, int] = {}
+
+    for i in range(nfunctab):
+        base = i * entry_size
+        if base + entry_size > len(functab):
+            break
+
+        pc_off = _u32(functab, base)
+        funcdata_rel = _u32(functab, base + ffs)
+
+        func_va = text_start + pc_off
+
+        # Func struct: [entry:uint32][nameoff:uint32]
+        nameoff_pos = funcdata_rel + ffs  # skip entry field (uint32)
+        if nameoff_pos + 4 > len(funcdata):
+            continue
+
+        nameoff = _u32(funcdata, nameoff_pos)
+        name = _cstring(funcnametab, nameoff)
+        if name:
+            funcs[name] = func_va
+
+    logger.debug("v118: extracted %d functions", len(funcs))
+    return funcs

--- a/scripts/debug_find_slicebytetostring.py
+++ b/scripts/debug_find_slicebytetostring.py
@@ -1,0 +1,117 @@
+"""
+Debug script to tesst/locate runtime.slicebytetostring call sites in a Go binary
+
+Usage:
+    python scripts/debug_find_slicebytetostring.py /path/to/binary.exe
+
+Flags:
+    --pclntab-only   skip vivisect analysis; only show pclntab symbol table
+    --all-funcs      dump every function name recovered from pclntab
+    --max N          max callsites to print per callee  (default: 20)
+"""
+
+import sys
+import logging
+import argparse
+
+import pefile
+import viv_utils
+
+from floss.language.go.extract import find_slicebytetostring_callsites
+from floss.language.go.pclntab import parse_pclntab, find_runtime_functions
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.WARNING
+    logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
+
+
+def _print_pclntab_info(path: str, all_funcs: bool) -> None:
+    try:
+        pe = pefile.PE(path, fast_load=True)
+    except Exception as exc:
+        print(f"[pclntab] could not open PE: {exc}")
+        return
+
+    funcs = parse_pclntab(pe)
+    if not funcs:
+        print("[pclntab] no functions recovered (pclntab not found or unparseable)")
+        return
+
+    print(f"[pclntab] recovered {len(funcs)} function names from pclntab")
+
+    hits = find_runtime_functions(pe, ("slicebytetostring",))
+    if hits:
+        print(f"\n[pclntab] slicebytetostring candidates ({len(hits)}):")
+        for name, va in sorted(hits.items(), key=lambda x: x[1]):
+            print(f"  0x{va:x}  {name}")
+    else:
+        print("[pclntab] no slicebytetostring symbol found in pclntab")
+
+    if all_funcs:
+        print(f"\n[pclntab] all {len(funcs)} recovered functions:")
+        for name, va in sorted(funcs.items(), key=lambda x: x[1]):
+            print(f"  0x{va:x}  {name}")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Locate runtime.slicebytetostring call sites in a Go binary",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("path", help="Path to Go PE binary")
+    parser.add_argument(
+        "--pclntab-only", action="store_true", help="Only show pclntab symbol table, skip vivisect analysis"
+    )
+    parser.add_argument("--all-funcs", action="store_true", help="Dump every function name recovered from pclntab")
+    parser.add_argument(
+        "--max", dest="max_callers", type=int, default=20, help="Max callsites to print per callee (default: 20)"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    _setup_logging(args.verbose)
+
+    # Always show pclntab summary first (fast, no vivisect needed)
+    _print_pclntab_info(args.path, args.all_funcs)
+
+    if args.pclntab_only:
+        return 0
+
+    # Full vivisect analysis
+    print(f"\n[vivisect] loading workspace for {args.path} ...")
+    try:
+        vw = viv_utils.getWorkspace(args.path, should_save=False)
+    except Exception as exc:
+        print(f"[vivisect] failed to load workspace: {exc}")
+        return 1
+
+    try:
+        pe = pefile.PE(args.path, fast_load=True)
+    except Exception:
+        pe = None
+
+    out = find_slicebytetostring_callsites(vw, pe=pe)
+
+    if not out:
+        print("[vivisect] no slicebytetostring callsites found")
+        return 0
+
+    total = sum(len(v) for v in out.values())
+    print(f"\n[vivisect] found {len(out)} callee(s), {total} total callsite(s)\n")
+
+    for callee, callers in sorted(out.items()):
+        name = vw.getName(callee) or "<unnamed>"
+        print(f"callee: 0x{callee:x}  name={name}  callers={len(callers)}")
+        shown = callers[: args.max_callers]
+        for va in shown:
+            print(f"  0x{va:x}")
+        if len(callers) > args.max_callers:
+            print(f"  ... and {len(callers) - args.max_callers} more")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_language_go_pclntab.py
+++ b/tests/test_language_go_pclntab.py
@@ -1,0 +1,515 @@
+"""
+Unit tests for floss.language.go.pclntab
+
+Each version specific test builds a minimal pclntab blob and
+verifies that the parser returns the expected name -> VA mapping. This lets us
+validate the parser logic without needing a real Go binary
+
+The integration test (test_parse_pclntab_real_binary) is skipped unless a
+pre-built Go binary exists at the expected fixture path
+"""
+
+import types
+import struct
+import pathlib
+import unittest.mock as mock
+
+import pytest
+
+from floss.language.go.pclntab import (
+    MAGIC_V12,
+    ALL_MAGICS,
+    MAGIC_V116,
+    MAGIC_V118,
+    MAGIC_V120,
+    _parse_v12,
+    _parse_v116,
+    _parse_v118,
+    parse_pclntab,
+    _locate_pclntab,
+    find_runtime_functions,
+)
+
+### Helpers to build minimal in-memory pclntab blobs
+
+
+def _build_v12(ptrsize: int, funcs: dict) -> bytes:
+    """
+    Build a minimal Go 1.2-style pclntab with the given {name: va} entries
+
+    Layout:
+        [magic:6][quantum:1][ptrsize:1]
+        nfunctab : uint(ptrsize)
+        functab  : nfunctab (va:P, data_off:P)  +  sentinel (va:P)
+        Func structs  : for each func: [entry:P][nameoff:4]
+        names    : null-terminated strings
+    """
+    p = "<I" if ptrsize == 4 else "<Q"
+
+    hdr = MAGIC_V12 + bytes([1, ptrsize])  # magic + quantum=1 + ptrsize
+
+    nfunctab = len(funcs)
+    nfunctab_bytes = struct.pack(p, nfunctab)
+
+    # We will compute offsets after we know the layout
+    # Pass 1: figure out where everything lands
+    functab_size = (nfunctab * 2 + 1) * ptrsize  # entries + sentinel_va
+    # NB: sentinel only has a va, no data_off   ← but Go uses (n*2+1)*ptrsize
+    # which means: n pairs of (va,off) + 1 lone va = n*2*ptrsize + ptrsize
+
+    header_end = 8 + ptrsize + functab_size  # end of header + nfunctab + functab
+    func_struct_base = header_end  # Func structs start here
+
+    # Each Func struct: entry(P) + nameoff(4)
+    func_struct_size = ptrsize + 4
+    name_base = func_struct_base + nfunctab * func_struct_size
+
+    names_list = list(funcs.keys())
+    name_offsets = {}
+    cur = name_base
+    for name in names_list:
+        name_offsets[name] = cur
+        cur += len(name) + 1  # +1 for null terminator
+
+    # Pass 2: build the bytes
+    buf = bytearray()
+    buf += hdr
+    buf += nfunctab_bytes
+
+    # functab: pairs + sentinel
+    for i, name in enumerate(names_list):
+        va = funcs[name]
+        data_off = func_struct_base + i * func_struct_size
+        buf += struct.pack(p, va)
+        buf += struct.pack(p, data_off)
+    # sentinel
+    buf += struct.pack(p, max(funcs.values()) + 0x100)
+
+    assert len(buf) == 8 + ptrsize + (nfunctab * 2 + 1) * ptrsize
+
+    # Func structs
+    for name in names_list:
+        va = funcs[name]
+        buf += struct.pack(p, va)  # entry
+        buf += struct.pack("<I", name_offsets[name])  # nameoff (into whole pclntab)
+
+    # Names
+    for name in names_list:
+        buf += name.encode() + b"\x00"
+
+    return bytes(buf)
+
+
+def _build_v116(ptrsize: int, funcs: dict) -> bytes:
+    """
+    Build a minimal Go 1.16-style pclntab
+
+    pcHeader after 8-byte magic/quantum/ptrsize:
+        [nfunctab:P][nfiletab:P][funcnameOff:P][cuOff:P][filetabOff:P][pctabOff:P][pclnOff:P]
+
+    pclntab[pclnOff] = functab + Func structs (funcdata region)
+    pclntab[funcnameOff] = funcnametab
+    """
+    p = "<I" if ptrsize == 4 else "<Q"
+
+    nfunctab = len(funcs)
+    names_list = list(funcs.keys())
+
+    # Build funcnametab: concatenated null-terminated names
+    funcnametab = bytearray()
+    name_offsets = {}
+    for name in names_list:
+        name_offsets[name] = len(funcnametab)
+        funcnametab += name.encode() + b"\x00"
+    funcnametab_bytes = bytes(funcnametab)
+
+    # Header size: 8 (magic/q/p) + 7 * ptrsize (nfunc, nfile, 5 offsets)
+    header_size = 8 + 7 * ptrsize
+
+    # funcnametab immediately follows header
+    funcname_off = header_size
+
+    # pcln (functab/funcdata) follows funcnametab
+    pcln_off = funcname_off + len(funcnametab_bytes)
+
+    # functab: (nfunctab*2+1) * ptrsize
+    ffs = ptrsize
+    functab_size = (nfunctab * 2 + 1) * ffs
+
+    # Func structs follow functab, within funcdata region
+    func_struct_base_in_funcdata = functab_size  # offset within funcdata
+    func_struct_size = ptrsize + 4  # entry(P) + nameoff(4)
+
+    # Build header
+    buf = bytearray()
+    buf += MAGIC_V116 + bytes([1, ptrsize])  # 8 bytes
+    buf += struct.pack(p, nfunctab)  # nfunctab
+    buf += struct.pack(p, 0)  # nfiletab
+    buf += struct.pack(p, funcname_off)  # funcnameOffset
+    buf += struct.pack(p, 0)  # cuOffset (unused in our test)
+    buf += struct.pack(p, 0)  # filetabOffset
+    buf += struct.pack(p, 0)  # pctabOffset
+    buf += struct.pack(p, pcln_off)  # pclnOffset
+
+    assert len(buf) == header_size
+
+    # funcnametab
+    buf += funcnametab_bytes
+
+    # funcdata region starts here (pcln_off)
+    funcdata_start = len(buf)
+    assert funcdata_start == pcln_off
+
+    # functab entries
+    for i, name in enumerate(names_list):
+        va = funcs[name]
+        funcdata_rel = func_struct_base_in_funcdata + i * func_struct_size
+        buf += struct.pack(p, va)  # va
+        buf += struct.pack(p, funcdata_rel)  # funcdata offset within funcdata region
+    # sentinel
+    buf += struct.pack(p, max(funcs.values()) + 0x100)
+
+    # Func structs
+    for name in names_list:
+        va = funcs[name]
+        buf += struct.pack(p, va)  # entry
+        buf += struct.pack("<I", name_offsets[name])  # nameoff into funcnametab
+
+    return bytes(buf)
+
+
+def _build_v118(ptrsize: int, funcs: dict, magic: bytes = MAGIC_V118) -> bytes:
+    """
+    Build a minimal Go 1.18-style pclntab
+
+    pcHeader after 8-byte magic/quantum/ptrsize:
+        [nfunctab:P][nfiletab:P][textStart:P][funcnameOff:P][cuOff:P]
+        [filetabOff:P][pctabOff:P][pclnOff:P]
+
+    All functab entries are uint32 (NOT pointer-sized).
+    func_va = textStart + pc_off_uint32.
+    """
+    p = "<I" if ptrsize == 4 else "<Q"
+
+    TEXT_START = 0x401000
+    nfunctab = len(funcs)
+    names_list = list(funcs.keys())
+
+    # funcnametab
+    funcnametab = bytearray()
+    name_offsets = {}
+    for name in names_list:
+        name_offsets[name] = len(funcnametab)
+        funcnametab += name.encode() + b"\x00"
+    funcnametab_bytes = bytes(funcnametab)
+
+    # Header: 8 + 8*ptrsize
+    header_size = 8 + 8 * ptrsize
+    funcname_off = header_size
+    pcln_off = funcname_off + len(funcnametab_bytes)
+
+    ffs = 4  # uint32 for 1.18
+    functab_size = (nfunctab * 2 + 1) * ffs
+    func_struct_base_in_funcdata = functab_size
+    func_struct_size = 4 + 4  # entry(uint32) + nameoff(uint32)
+
+    buf = bytearray()
+    buf += magic + bytes([1, ptrsize])  # 8 bytes
+    buf += struct.pack(p, nfunctab)  # nfunctab
+    buf += struct.pack(p, 0)  # nfiletab
+    buf += struct.pack(p, TEXT_START)  # textStart
+    buf += struct.pack(p, funcname_off)  # funcnameOffset
+    buf += struct.pack(p, 0)  # cuOffset
+    buf += struct.pack(p, 0)  # filetabOffset
+    buf += struct.pack(p, 0)  # pctabOffset
+    buf += struct.pack(p, pcln_off)  # pclnOffset
+
+    assert len(buf) == header_size
+
+    buf += funcnametab_bytes
+
+    # functab
+    for i, name in enumerate(names_list):
+        va = funcs[name]
+        pc_off = va - TEXT_START
+        funcdata_rel = func_struct_base_in_funcdata + i * func_struct_size
+        buf += struct.pack("<I", pc_off)  # pc_off from textStart
+        buf += struct.pack("<I", funcdata_rel)  # funcdata offset
+
+    # sentinel
+    sentinel_pc_off = max(v - TEXT_START for v in funcs.values()) + 0x100
+    buf += struct.pack("<I", sentinel_pc_off)
+
+    # Func structs
+    for name in names_list:
+        va = funcs[name]
+        pc_off = va - TEXT_START
+        buf += struct.pack("<I", pc_off)  # entry
+        buf += struct.pack("<I", name_offsets[name])  # nameoff
+
+    return bytes(buf)
+
+
+### Unit tests: parser internals
+
+
+class TestParseV12:
+    def test_single_function_ptrsize8(self):
+        data = _build_v12(8, {"runtime.slicebytetostring": 0x401000})
+        result = _parse_v12(data, 8)
+        assert result == {"runtime.slicebytetostring": 0x401000}
+
+    def test_single_function_ptrsize4(self):
+        data = _build_v12(4, {"runtime.slicebytetostring": 0x401000})
+        result = _parse_v12(data, 4)
+        assert result == {"runtime.slicebytetostring": 0x401000}
+
+    def test_multiple_functions(self):
+        funcs = {
+            "runtime.slicebytetostring": 0x401000,
+            "runtime.memmove": 0x402000,
+            "main.main": 0x403000,
+        }
+        data = _build_v12(8, funcs)
+        result = _parse_v12(data, 8)
+        assert result == funcs
+
+    def test_empty_data_returns_empty(self):
+        assert _parse_v12(b"", 8) == {}
+
+    def test_truncated_data_returns_partial(self):
+        data = _build_v12(8, {"runtime.slicebytetostring": 0x401000})
+        # Truncate the name bytes — should return empty (name not readable)
+        result = _parse_v12(data[:40], 8)
+        assert isinstance(result, dict)  # no crash
+
+
+class TestParseV116:
+    def test_single_function_ptrsize8(self):
+        data = _build_v116(8, {"runtime.slicebytetostring": 0x401000})
+        result = _parse_v116(data, 8)
+        assert result == {"runtime.slicebytetostring": 0x401000}
+
+    def test_single_function_ptrsize4(self):
+        data = _build_v116(4, {"runtime.slicebytetostring": 0x401000})
+        result = _parse_v116(data, 4)
+        assert result == {"runtime.slicebytetostring": 0x401000}
+
+    def test_multiple_functions(self):
+        funcs = {
+            "runtime.slicebytetostring": 0x401000,
+            "runtime.memmove": 0x402000,
+            "main.main": 0x403000,
+        }
+        data = _build_v116(8, funcs)
+        result = _parse_v116(data, 8)
+        assert result == funcs
+
+    def test_empty_data_returns_empty(self):
+        assert _parse_v116(b"", 8) == {}
+
+
+class TestParseV118:
+    def test_single_function_v118_ptrsize8(self):
+        data = _build_v118(8, {"runtime.slicebytetostring": 0x401500})
+        result = _parse_v118(data, 8)
+        assert result == {"runtime.slicebytetostring": 0x401500}
+
+    def test_single_function_ptrsize4(self):
+        data = _build_v118(4, {"runtime.slicebytetostring": 0x401500})
+        result = _parse_v118(data, 4)
+        assert result == {"runtime.slicebytetostring": 0x401500}
+
+    def test_v120_magic(self):
+        # 1.20 uses same layout as 1.18, only magic differs
+        data = _build_v118(8, {"runtime.slicebytetostring": 0x401500}, magic=MAGIC_V120)
+        result = _parse_v118(data, 8)
+        assert result == {"runtime.slicebytetostring": 0x401500}
+
+    def test_multiple_functions(self):
+        TEXT_START = 0x401000
+        funcs = {
+            "runtime.slicebytetostring": TEXT_START + 0x500,
+            "runtime.memmove": TEXT_START + 0x1000,
+            "main.main": TEXT_START + 0x2000,
+        }
+        data = _build_v118(8, funcs)
+        result = _parse_v118(data, 8)
+        assert result == funcs
+
+    def test_empty_data_returns_empty(self):
+        assert _parse_v118(b"", 8) == {}
+
+
+### Unit tests: locate_pclntab via fake PE
+
+
+def _fake_pe(sections: list) -> mock.MagicMock:
+    """
+    Build a minimal mock pefile.PE with the given sections
+    Each section is a dict with keys: Name (bytes), VirtualAddress (int), data (bytes).
+    """
+    pe = mock.MagicMock()
+    pe.OPTIONAL_HEADER.ImageBase = 0x400000
+
+    fake_sections = []
+    for s in sections:
+        sec = mock.MagicMock()
+        sec.Name = s["Name"]
+        sec.VirtualAddress = s["VirtualAddress"]
+        sec.get_data.return_value = s["data"]
+        fake_sections.append(sec)
+
+    pe.sections = fake_sections
+    return pe
+
+
+class TestLocatePclntab:
+    def test_named_section_gopclntab(self):
+        pclntab_data = _build_v118(8, {"runtime.foo": 0x401500})
+        pe = _fake_pe(
+            [
+                {"Name": b".gopclntab\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x5000, "data": pclntab_data},
+            ]
+        )
+        va, data = _locate_pclntab(pe)
+        assert data[:6] == MAGIC_V118
+        assert va == 0x400000 + 0x5000
+
+    def test_magic_scan_fallback(self):
+        pclntab_data = _build_v118(8, {"runtime.foo": 0x401500})
+        # Section name does NOT match — simulates stripped/obfuscated binary
+        pe = _fake_pe(
+            [
+                {"Name": b".data\x00\x00\x00\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x5000, "data": pclntab_data},
+            ]
+        )
+        va, data = _locate_pclntab(pe)
+        assert data[:6] == MAGIC_V118
+
+    def test_not_found_raises(self):
+        pe = _fake_pe(
+            [
+                {"Name": b".text\x00\x00\x00\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x1000, "data": b"\x00" * 64},
+            ]
+        )
+        with pytest.raises(ValueError, match="pclntab not found"):
+            _locate_pclntab(pe)
+
+
+class TestParsePclntab:
+    """End-to-end tests through the public parse_pclntab() API using mock PEs"""
+
+    def _make_pe(self, pclntab_data: bytes):
+        return _fake_pe(
+            [
+                {"Name": b".gopclntab\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x5000, "data": pclntab_data},
+            ]
+        )
+
+    def test_v12(self):
+        data = _build_v12(8, {"runtime.slicebytetostring": 0x401000})
+        pe = self._make_pe(data)
+        result = parse_pclntab(pe)
+        assert "runtime.slicebytetostring" in result
+        assert result["runtime.slicebytetostring"] == 0x401000
+
+    def test_v116(self):
+        data = _build_v116(8, {"runtime.slicebytetostring": 0x401000})
+        pe = self._make_pe(data)
+        result = parse_pclntab(pe)
+        assert result.get("runtime.slicebytetostring") == 0x401000
+
+    def test_v118(self):
+        data = _build_v118(8, {"runtime.slicebytetostring": 0x401500})
+        pe = self._make_pe(data)
+        result = parse_pclntab(pe)
+        assert result.get("runtime.slicebytetostring") == 0x401500
+
+    def test_v120(self):
+        data = _build_v118(8, {"runtime.slicebytetostring": 0x401500}, magic=MAGIC_V120)
+        pe = self._make_pe(data)
+        result = parse_pclntab(pe)
+        assert result.get("runtime.slicebytetostring") == 0x401500
+
+    def test_missing_pclntab_returns_empty(self):
+        pe = _fake_pe(
+            [
+                {"Name": b".text\x00\x00\x00\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x1000, "data": b"\x00" * 64},
+            ]
+        )
+        result = parse_pclntab(pe)
+        assert result == {}
+
+
+class TestFindRuntimeFunctions:
+    def test_find_slicebytetostring(self):
+        funcs = {
+            "runtime.slicebytetostring": 0x401000,
+            "runtime.memmove": 0x402000,
+            "main.main": 0x403000,
+        }
+        data = _build_v118(8, funcs)
+        pe = _fake_pe(
+            [
+                {"Name": b".gopclntab\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x5000, "data": data},
+            ]
+        )
+        result = find_runtime_functions(pe, ("slicebytetostring",))
+        assert "runtime.slicebytetostring" in result
+        assert result["runtime.slicebytetostring"] == 0x401000
+        assert "runtime.memmove" not in result
+
+    def test_case_insensitive(self):
+        data = _build_v118(8, {"runtime.SliceByteToString": 0x401000})
+        pe = _fake_pe(
+            [
+                {"Name": b".gopclntab\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x5000, "data": data},
+            ]
+        )
+        result = find_runtime_functions(pe, ("slicebytetostring",))
+        assert "runtime.SliceByteToString" in result
+
+    def test_no_match_returns_empty(self):
+        data = _build_v118(8, {"runtime.memmove": 0x401000})
+        pe = _fake_pe(
+            [
+                {"Name": b".gopclntab\x00\x00\x00\x00\x00\x00", "VirtualAddress": 0x5000, "data": data},
+            ]
+        )
+        result = find_runtime_functions(pe, ("slicebytetostring",))
+        assert result == {}
+
+
+# Integration test: real Go binary fixture
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent / "data" / "language" / "go"
+
+
+def _collect_go_fixtures():
+    if not _FIXTURE_DIR.exists():
+        return []
+    exts = (".exe", ".exe_", "")
+    return [p for p in _FIXTURE_DIR.rglob("*") if p.is_file() and (p.suffix in exts or p.name.endswith(".exe_"))]
+
+
+@pytest.mark.parametrize("fixture_path", _collect_go_fixtures())
+def test_parse_pclntab_real_binary(fixture_path: pathlib.Path):
+    """
+    parse_pclntab on every Go binary fixture in the test data
+    We only require that the call does not raise and returns a dict
+    """
+    import pefile
+
+    try:
+        pe = pefile.PE(str(fixture_path), fast_load=True)
+    except Exception:
+        pytest.skip(f"pefile could not open {fixture_path}")
+
+    result = parse_pclntab(pe)
+    assert isinstance(result, dict)
+    # For real Go binaries we expect at least some functions
+    if result:
+        assert any(
+            "runtime" in name or "main" in name for name in result.keys()
+        ), f"No runtime/main functions found in {fixture_path}: got {list(result.keys())[:5]}"


### PR DESCRIPTION
Resolves #828 

This PR aims to implement :
-  Go-specific decoded stackstring pass that locates runtime.slicebytetostring (and common aliases) in the vivisect workspace and collects its callsites
- Follows the idea : `Note that generally decoding strings such as this involves converting a byte array back into a string, so stackstrings are typically followed by a call to runtime_slicebytetostring` as discussed in #828 

Till now a module has been added(`pclntab.py`) to parse Go metadata (pclntab/moduledata) for function names and addresses as the repo doesnt have Go runtime symbol resolution helpers.
This is used to locate `runtime.slicebytetostring` ,  function VA of `runtime.slicebytetostring`  and list of call sites.
<img width="806" height="815" alt="pclntab_floss" src="https://github.com/user-attachments/assets/f0543bb4-a183-4531-a8e0-0163efe0a1d7" />


Next steps would be to , recover the decoded bytes at each identified call site and hence the runtime stackstrings.

References/Inspirations for the work : 
- https://github.com/[dipusone/golang_pclntab_parser](https://github.com/dipusone/golang_pclntab_parser)
- https://go.dev/src/debug/gosym/pclntab.go

Note : For `test_language_go_pclntab.py` help of copilot was taken to build version specific minimal pclntab blob