### PR TITLE
Refactor language coverage module

### DIFF
--- a/floss/language/cli_common.py
+++ b/floss/language/cli_common.py
@@ -1,0 +1,39 @@
+import logging
+import argparse
+
+import pefile
+
+
+def add_common_args(parser: argparse.ArgumentParser, default_min_length: int):
+    parser.add_argument("path", help="file or path to analyze")
+    parser.add_argument(
+        "-n",
+        "--minimum-length",
+        dest="min_length",
+        type=int,
+        default=default_min_length,
+        help="minimum string length",
+    )
+
+    logging_group = parser.add_argument_group("logging arguments")
+    logging_group.add_argument("-d", "--debug", action="store_true", help="enable debugging output on STDERR")
+    logging_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="disable all status output except fatal errors",
+    )
+
+
+def configure_logging(debug):
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(level=level)
+    logging.getLogger().setLevel(level)
+
+
+def open_pe_or_none(path: str, logger: logging.Logger):
+    try:
+        return pefile.PE(path)
+    except pefile.PEFormatError as err:
+        logger.debug(f"NOT a valid PE file: {err}")
+        return None

--- a/floss/language/cli_common.py
+++ b/floss/language/cli_common.py
@@ -1,7 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import argparse
 
 import pefile
+
+logger = logging.getLogger(__name__)
 
 
 def add_common_args(parser: argparse.ArgumentParser, default_min_length: int):
@@ -25,13 +41,16 @@ def add_common_args(parser: argparse.ArgumentParser, default_min_length: int):
     )
 
 
-def configure_logging(debug):
-    level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(level=level)
-    logging.getLogger().setLevel(level)
+def configure_logging(args: argparse.Namespace):
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+        logging.getLogger().setLevel(logging.INFO)
 
 
-def open_pe_or_none(path: str, logger: logging.Logger):
+def open_pe_or_none(path: str):
     try:
         return pefile.PE(path)
     except pefile.PEFormatError as err:

--- a/floss/language/cli_common.py
+++ b/floss/language/cli_common.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 
 import logging
 import argparse
-
-import pefile
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +46,3 @@ def configure_logging(args: argparse.Namespace):
     else:
         logging.basicConfig(level=logging.INFO)
         logging.getLogger().setLevel(logging.INFO)
-
-
-def open_pe_or_none(path: str):
-    try:
-        return pefile.PE(path)
-    except pefile.PEFormatError as err:
-        logger.debug(f"NOT a valid PE file: {err}")
-        return None

--- a/floss/language/go/coverage.py
+++ b/floss/language/go/coverage.py
@@ -23,6 +23,7 @@ import pefile
 from floss.utils import get_static_strings
 from floss.results import StaticString, StringEncoding
 from floss.language.utils import get_extract_stats
+from floss.language.cli_common import add_common_args, open_pe_or_none, configure_logging
 from floss.language.go.extract import extract_go_strings
 
 logger = logging.getLogger(__name__)
@@ -32,36 +33,13 @@ MIN_STR_LEN = 4
 
 def main():
     parser = argparse.ArgumentParser(description="Get Go strings")
-    parser.add_argument("path", help="file or path to analyze")
-    parser.add_argument(
-        "-n",
-        "--minimum-length",
-        dest="min_length",
-        type=int,
-        default=MIN_STR_LEN,
-        help="minimum string length",
-    )
-    logging_group = parser.add_argument_group("logging arguments")
-    logging_group.add_argument("-d", "--debug", action="store_true", help="enable debugging output on STDERR")
-    logging_group.add_argument(
-        "-q",
-        "--quiet",
-        action="store_true",
-        help="disable all status output except fatal errors",
-    )
+    add_common_args(parser, default_min_length=MIN_STR_LEN)
     args = parser.parse_args()
 
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
-        logging.getLogger().setLevel(logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.INFO)
-        logging.getLogger().setLevel(logging.INFO)
+    configure_logging(debug=args.debug)
 
-    try:
-        pe = pefile.PE(args.path)
-    except pefile.PEFormatError as err:
-        logger.debug(f"NOT a valid PE file: {err}")
+    pe = open_pe_or_none(args.path, logger)
+    if pe is None:
         return 1
 
     path = pathlib.Path(args.path)

--- a/floss/language/go/coverage.py
+++ b/floss/language/go/coverage.py
@@ -18,8 +18,6 @@ import pathlib
 import argparse
 from typing import List
 
-import pefile
-
 from floss.utils import get_static_strings
 from floss.results import StaticString, StringEncoding
 from floss.language.utils import get_extract_stats
@@ -33,12 +31,12 @@ MIN_STR_LEN = 4
 
 def main():
     parser = argparse.ArgumentParser(description="Get Go strings")
-    add_common_args(parser, default_min_length=MIN_STR_LEN)
+    add_common_args(parser, MIN_STR_LEN)
     args = parser.parse_args()
 
-    configure_logging(debug=args.debug)
+    configure_logging(args)
 
-    pe = open_pe_or_none(args.path, logger)
+    pe = open_pe_or_none(args.path)
     if pe is None:
         return 1
 

--- a/floss/language/go/coverage.py
+++ b/floss/language/go/coverage.py
@@ -18,10 +18,12 @@ import pathlib
 import argparse
 from typing import List
 
+import pefile
+
 from floss.utils import get_static_strings
 from floss.results import StaticString, StringEncoding
 from floss.language.utils import get_extract_stats
-from floss.language.cli_common import add_common_args, open_pe_or_none, configure_logging
+from floss.language.cli_common import add_common_args, configure_logging
 from floss.language.go.extract import extract_go_strings
 
 logger = logging.getLogger(__name__)
@@ -36,8 +38,10 @@ def main():
 
     configure_logging(args)
 
-    pe = open_pe_or_none(args.path)
-    if pe is None:
+    try:
+        pe = pefile.PE(args.path)
+    except pefile.PEFormatError as err:
+        logger.debug(f"NOT a valid PE file: {err}")
         return 1
 
     path = pathlib.Path(args.path)

--- a/floss/language/rust/coverage.py
+++ b/floss/language/rust/coverage.py
@@ -23,6 +23,7 @@ import pefile
 
 from floss.strings import extract_ascii_unicode_strings
 from floss.language.utils import get_extract_stats
+from floss.language.cli_common import add_common_args, open_pe_or_none, configure_logging
 from floss.language.rust.extract import extract_rust_strings
 
 logger = logging.getLogger(__name__)
@@ -32,36 +33,13 @@ MIN_STR_LEN = 4
 
 def main():
     parser = argparse.ArgumentParser(description="Get Rust strings")
-    parser.add_argument("path", help="file or path to analyze")
-    parser.add_argument(
-        "-n",
-        "--minimum-length",
-        dest="min_length",
-        type=int,
-        default=MIN_STR_LEN,
-        help="minimum string length",
-    )
-    logging_group = parser.add_argument_group("logging arguments")
-    logging_group.add_argument("-d", "--debug", action="store_true", help="enable debugging output on STDERR")
-    logging_group.add_argument(
-        "-q",
-        "--quiet",
-        action="store_true",
-        help="disable all status output except fatal errors",
-    )
+    add_common_args(parser, default_min_length=MIN_STR_LEN)
     args = parser.parse_args()
 
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
-        logging.getLogger().setLevel(logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.INFO)
-        logging.getLogger().setLevel(logging.INFO)
+    configure_logging(debug=args.debug)
 
-    try:
-        pe = pefile.PE(args.path)
-    except pefile.PEFormatError as err:
-        logger.debug(f"NOT a valid PE file: {err}")
+    pe = open_pe_or_none(args.path, logger)
+    if pe is None:
         return 1
 
     path = pathlib.Path(args.path)

--- a/floss/language/rust/coverage.py
+++ b/floss/language/rust/coverage.py
@@ -33,12 +33,12 @@ MIN_STR_LEN = 4
 
 def main():
     parser = argparse.ArgumentParser(description="Get Rust strings")
-    add_common_args(parser, default_min_length=MIN_STR_LEN)
+    add_common_args(parser, MIN_STR_LEN)
     args = parser.parse_args()
 
-    configure_logging(debug=args.debug)
+    configure_logging(args)
 
-    pe = open_pe_or_none(args.path, logger)
+    pe = open_pe_or_none(args.path)
     if pe is None:
         return 1
 

--- a/floss/language/rust/coverage.py
+++ b/floss/language/rust/coverage.py
@@ -23,7 +23,7 @@ import pefile
 
 from floss.strings import extract_ascii_unicode_strings
 from floss.language.utils import get_extract_stats
-from floss.language.cli_common import add_common_args, open_pe_or_none, configure_logging
+from floss.language.cli_common import add_common_args, configure_logging
 from floss.language.rust.extract import extract_rust_strings
 
 logger = logging.getLogger(__name__)
@@ -38,8 +38,10 @@ def main():
 
     configure_logging(args)
 
-    pe = open_pe_or_none(args.path)
-    if pe is None:
+    try:
+        pe = pefile.PE(args.path)
+    except pefile.PEFormatError as err:
+        logger.debug(f"NOT a valid PE file: {err}")
         return 1
 
     path = pathlib.Path(args.path)

--- a/floss/main.py
+++ b/floss/main.py
@@ -126,7 +126,8 @@ def make_parser(argv):
         " 1. Go:   strings from binaries written in Go\n"
         " 2. Rust: strings from binaries written in Rust\n"
     )
-    epilog = textwrap.dedent("""
+    epilog = textwrap.dedent(
+        """
         only displaying core arguments, run `floss -H` to see all supported options
 
         examples:
@@ -138,8 +139,10 @@ def make_parser(argv):
 
           only extract stack and tight strings
             floss --only stack tight -- suspicious.exe
-        """)
-    epilog_advanced = textwrap.dedent("""
+        """
+    )
+    epilog_advanced = textwrap.dedent(
+        """
         examples:
           extract all strings from 32-bit shellcode
             floss -f sc32 shellcode.bin
@@ -149,7 +152,8 @@ def make_parser(argv):
         
           extract strings from a binary written in Go (if automatic language identification fails)
             floss --language go program.exe
-        """)
+        """
+    )
 
     show_all_options = "-H" in argv
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -3,7 +3,8 @@ import textwrap
 import floss.main
 
 # floss --no static -j tests/data/src/decode-in-place/bin/test-decode-in-place.exe
-RESULTS = textwrap.dedent("""
+RESULTS = textwrap.dedent(
+    """
 {
     "analysis": {
         "enable_decoded_strings": true,
@@ -83,7 +84,8 @@ RESULTS = textwrap.dedent("""
         "tight_strings": []
     }
 }
-""")
+"""
+)
 
 
 def test_load(tmp_path):


### PR DESCRIPTION
Resolves #1213 

Introduces `language/cli_common.py`, deduplicating the argument parsing , logging setup, and PE validation logic into one file.
Makes it easier for setting up new languages