### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/floss/language/identify.py
+++ b/floss/language/identify.py
@@ -205,7 +205,7 @@ def verify_pclntab(section, pclntab_va: int) -> bool:
     try:
         pc_quanum = section.get_data(pclntab_va + 6, 1)[0]
         pointer_size = section.get_data(pclntab_va + 7, 1)[0]
-    except:
+    except Exception:
         logger.error("Error parsing pclntab header")
         return False
     return True if pc_quanum in {1, 2, 4} and pointer_size in {4, 8} else False

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -368,7 +368,7 @@ def redirecting_print_to_tqdm():
         # If tqdm.tqdm.write raises error, use builtin print
         try:
             tqdm.tqdm.write(*args, **kwargs)
-        except:
+        except Exception:
             old_print(*args, **kwargs)
 
     try:


### PR DESCRIPTION
Replaces 2 bare `except:` with `except Exception:` in `floss/utils.py` and `floss/language/identify.py`.