### PR TITLE
Finish folding of QS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ the layout-aware static listing when deobfuscation is enabled.
 ```console
 $ floss sample.exe
 $ floss sample.exe -j
-$ floss --no-layout sample.exe    # classic static listing
-$ floss --no-tags sample.exe      # layout without tag databases
 ```
 
 Features:
@@ -89,16 +87,15 @@ Extract obfuscated strings from a malware binary:
 
 Only extract stack and tight strings:
 
-    $ floss --only stack tight -- suspicious.exe
+    $ floss --string-type stack tight -- suspicious.exe
 
 Do not extract static strings:
 
-    $ floss --no static -- backdoor.exe
+    $ floss --no-string-type static -- backdoor.exe
 
 Display the help/usage screens:
 
-    $ floss -h  # show core arguments
-    $ floss -H  # show all supported arguments
+    $ floss -h  # show all supported arguments
 
 For a detailed description of using FLOSS, review the documentation
  [here](doc/usage.md).

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -18,9 +18,7 @@ Since FLOSS also extracts static strings (like `strings.exe`),
 Here's a summary of the command line flags and options you
  can provide to FLOSS to modify its behavior.
 
-See `floss -h` for all supported arguments and usage examples. This displays the most used arguments only.
-
-To see all supported arguments run `floss -H`.
+See `floss -h` for all supported arguments and usage examples.
 
 ### Extract static, obfuscated, and stack strings (default mode)
 
@@ -42,33 +40,33 @@ FLOSS can identify programs compiled from selected programming languages and ext
 
 By default, this process is automatic. However, you can use the `--language` argument to manually select or disable this feature.
 
-### Disable string type extraction (`--no {static,decoded,stack,tight}`)
+### Disable string type extraction (`--no-string-type {static,decoded,stack,tight,all}`)
 
 When FLOSS searches for static strings, it looks for
  human-readable ASCII and UTF-16 strings across the
  entire binary contents of the file.
 This means you may be able to replace `strings.exe` with
  FLOSS in your analysis workflow. However, you may disable
- the extraction of static strings via the `--no static` switch.
+ the extraction of static strings via the `--no-string-type static` switch.
 
-    floss.exe --no static -- malware.exe
+    floss.exe --no-string-type static -- malware.exe
 
-Since `--no` supports multiple arguments, end the command options with a double dash `--`.
+Since `--no-string-type` supports multiple arguments, end the command options with a double dash `--`.
 
 Analogous, you can disable the extraction of obfuscated strings, stackstrings or any combination.
 
-    floss.exe --no decoded -- malware.exe
-    floss.exe --no stack tight -- malware.exe
+    floss.exe --no-string-type decoded -- malware.exe
+    floss.exe --no-string-type stack tight -- malware.exe
 
 
-### Enable string type extraction (`--only {static,decoded,stack,tight}`)
+### Enable string type extraction (`--string-type {static,decoded,stack,tight,all}`)
 
 Sometimes it's easier to specify only the string type(s) you want to extract.
-Use the `--only` option for that.
+Use the `--string-type` option for that.
 
-    floss.exe --only decoded -- malware.exe
+    floss.exe --string-type decoded -- malware.exe
 
-Please note that `--no` and `--only` cannot be used at the same time.
+Please note that `--string-type` and `--no-string-type` cannot be used at the same time.
 
 ### Write output as JSON (`-j/--json`)
 
@@ -76,11 +74,12 @@ Write FLOSS results to `stdout` structured in JSON to make it easy to ingest by 
 
     floss.exe -j malware.exe > malware_strings.json
 
-### Load FLOSS results (`-l/--load`)
+### Load FLOSS results (automatic)
 
-Load a FLOSS results JSON document. This allows to explore FLOSS results without re-running the analysis.
+Loading a saved FLOSS results JSON document is automatic and detected from the file
+content, so you can explore results without re-running the analysis.
 
-    floss.exe -l malware_floss_results.json
+    floss.exe malware_floss_results.json
 
 
 ### Verbose results (`-v`)
@@ -120,10 +119,10 @@ Supplying a larger minimum length reduces the chances
     floss.exe -n 10 malware.exe
 
 
-### Decoding function specification (`--functions`)
+### Decoding function specification (`--analyze-functions`)
 
 You can instruct FLOSS to decode the strings provided
- to specific functions by using the `--functions`
+ to specific functions by using the `--analyze-functions`
  option.
 By default, FLOSS uses heuristics to identify decoding
  routines in malware.
@@ -137,7 +136,7 @@ This can improve performance as FLOSS by perhaps one-third
   to always manually identify decoding routines).
 Specify functions by using their hex-encoded virtual address.
 
-    floss.exe --functions 0x401000 0x402000 malware.exe
+    floss.exe --analyze-functions 0x401000 0x402000 malware.exe
 
 
 ### Install/Uninstall right click menu option for Windows (`--install-right-click-menu/--uninstall-right-click-menu`)

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -53,6 +53,11 @@ class StringType(str, Enum):
     DECODED = "decoded"
 
 
+# string types selectable via --string-type / --no-string-type; "all" is a convenience
+# for every type at once (the default).
+STRING_TYPE_CHOICES = [t.value for t in StringType] + ["all"]
+
+
 class WorkspaceLoadError(ValueError):
     pass
 
@@ -76,7 +81,7 @@ class ArgumentParser(argparse.ArgumentParser):
         raise ArgumentValueError("%(prog)s: error: %(message)s" % args)
 
 
-def make_parser(argv):
+def make_parser():
     desc = (
         "The FLARE team's open-source tool to extract ALL strings from malware.\n"
         f"  %(prog)s {__version__} - https://github.com/mandiant/flare-floss/\n\n"
@@ -89,46 +94,34 @@ def make_parser(argv):
         " 1. Go:   strings from binaries written in Go\n"
         " 2. Rust: strings from binaries written in Rust\n\n"
         "By default, static strings are layout-aware with tags for PE/ELF/Mach-O\n"
-        "(section context, prevalence/library/expert tags). Disable with:\n"
-        "  --no-layout   or   --no-tags\n"
-        "(temporary flags; CLI cleanup tracked in github.com/mandiant/flare-floss/issues/1348)\n"
+        "(section context, prevalence/library/expert tags).\n"
     )
     epilog = textwrap.dedent("""
-        only displaying core arguments, run `floss -H` to see all supported options
-
         examples:
           extract all strings from an executable
             floss suspicious.exe
 
           do not extract static strings
-            floss --no static -- suspicious.exe
+            floss --no-string-type static -- suspicious.exe
 
           only extract stack and tight strings
-            floss --only stack tight -- suspicious.exe
+            floss --string-type stack tight -- suspicious.exe
 
-          classic static strings without layout/tags
-            floss --no-layout -- suspicious.exe
-        """)
-    epilog_advanced = textwrap.dedent("""
-        examples:
-          extract all strings from 32-bit shellcode
+          extract strings from 32-bit shellcode
             floss -f sc32 shellcode.bin
 
           only decode strings from the specified functions
-            floss --functions 0x401000 0x401100 suspicious.exe
+            floss --analyze-functions 0x401000 0x401100 suspicious.exe
 
           extract strings from a binary written in Go (if automatic language identification fails)
             floss --language go program.exe
         """)
 
-    show_all_options = "-H" in argv
-
     parser = ArgumentParser(
         description=desc,
-        epilog=epilog_advanced if show_all_options else epilog,
+        epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("-H", action="help", help="show advanced options and exit")
     parser.add_argument(
         "-n",
         "--minimum-length",
@@ -146,33 +139,22 @@ def make_parser(argv):
 
     analysis_group = parser.add_argument_group("analysis arguments")
     analysis_group.add_argument(
-        "--no",
-        action="extend",
-        dest="disabled_types",
-        nargs="+",
-        choices=[t.value for t in StringType],
-        default=[],
-        help="do not extract specified string type(s)",
-    )
-    analysis_group.add_argument(
-        "--only",
+        "--string-type",
         action="extend",
         dest="enabled_types",
         nargs="+",
-        choices=[t.value for t in StringType],
+        choices=STRING_TYPE_CHOICES,
         default=[],
-        help="only extract specified string type(s)",
-    )
-    # temporary product toggles (not string types); see issue #1348 for CLI cleanup
-    analysis_group.add_argument(
-        "--no-layout",
-        action="store_true",
-        help="disable layout-aware static analysis (classic flat static listing)",
+        help="only extract specified string type(s); valid values: %s" % ", ".join(STRING_TYPE_CHOICES),
     )
     analysis_group.add_argument(
-        "--no-tags",
-        action="store_true",
-        help="disable tag databases (layout sections without prevalence/library tags)",
+        "--no-string-type",
+        action="extend",
+        dest="disabled_types",
+        nargs="+",
+        choices=STRING_TYPE_CHOICES,
+        default=[],
+        help="do not extract specified string type(s); valid values: %s" % ", ".join(STRING_TYPE_CHOICES),
     )
 
     advanced_group = parser.add_argument_group("advanced arguments")
@@ -188,86 +170,57 @@ def make_parser(argv):
         "--format",
         choices=[f[0] for f in formats],
         default="auto",
-        help="select sample format, %s" % format_help if show_all_options else argparse.SUPPRESS,
+        help="select sample format, %s" % format_help,
     )
     advanced_group.add_argument(
         "--language",
         type=str,
         choices=[l.value for l in Language if l != Language.UNKNOWN],
         default=Language.UNKNOWN.value,
-        help=(
-            "use language-specific string extraction, auto-detect language by default, disable using 'none'"
-            if show_all_options
-            else argparse.SUPPRESS
-        ),
+        help="use language-specific string extraction, auto-detect language by default, disable using 'none'",
     )
     advanced_group.add_argument(
-        "-l",
-        "--load",
-        action="store_true",
-        help="load from existing FLOSS results document" if show_all_options else argparse.SUPPRESS,
-    )
-    advanced_group.add_argument(
-        "--functions",
+        "--analyze-functions",
+        dest="functions",
         type=lambda x: int(x, 0x10),
         default=None,
         nargs="+",
-        help=(
-            "only analyze the specified functions, hex-encoded like 0x401000, space-separate multiple functions"
-            if show_all_options
-            else argparse.SUPPRESS
-        ),
+        help="only analyze the specified functions, hex-encoded like 0x401000, space-separate multiple functions",
     )
     advanced_group.add_argument(
         "--disable-progress",
         action="store_true",
-        help="disable all progress bars" if show_all_options else argparse.SUPPRESS,
+        help="disable all progress bars",
     )
     advanced_group.add_argument(
         "--signatures",
         type=str,
         default=SIGNATURES_PATH_DEFAULT_STRING,
-        help=(
-            "path to .sig/.pat file or directory used to identify library functions, use embedded signatures by default"
-            if show_all_options
-            else argparse.SUPPRESS
-        ),
+        help="path to .sig/.pat file or directory used to identify library functions, use embedded signatures by default",
     )
     advanced_group.add_argument(
         "-L",
         "--large-file",
         action="store_true",
-        help=(
-            "allow processing files larger than {} MB".format(int(MAX_FILE_SIZE / MEGABYTE))
-            if show_all_options
-            else argparse.SUPPRESS
-        ),
+        help="allow processing files larger than {} MB".format(int(MAX_FILE_SIZE / MEGABYTE)),
     )
     advanced_group.add_argument(
         "--version",
         action="version",
         version="%(prog)s {:s}".format(__version__),
-        help="show program's version number and exit" if show_all_options else argparse.SUPPRESS,
+        help="show program's version number and exit",
     )
     if sys.platform == "win32":
         advanced_group.add_argument(
             "--install-right-click-menu",
             action=floss.utils.InstallContextMenu,
-            help=(
-                "install FLOSS to the right-click context menu for Windows Explorer and exit"
-                if show_all_options
-                else argparse.SUPPRESS
-            ),
+            help="install FLOSS to the right-click context menu for Windows Explorer and exit",
         )
 
         advanced_group.add_argument(
             "--uninstall-right-click-menu",
             action=floss.utils.UninstallContextMenu,
-            help=(
-                "uninstall FLOSS from the right-click context menu for Windows Explorer and exit"
-                if show_all_options
-                else argparse.SUPPRESS
-            ),
+            help="uninstall FLOSS from the right-click context menu for Windows Explorer and exit",
         )
 
     output_group = parser.add_argument_group("rendering arguments")

--- a/floss/main.py
+++ b/floss/main.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import sys
+from typing import List
 from pathlib import Path
 
 import rich.traceback
@@ -44,6 +45,41 @@ def is_running_standalone() -> bool:
     return hasattr(sys, "frozen") and hasattr(sys, "_MEIPASS")
 
 
+def is_results_document(sample: Path) -> bool:
+    """
+    Heuristically detect a saved FLOSS results document from its content.
+
+    A results document is JSON, so the first non-whitespace byte is ``{``.
+    Binary samples (PE/ELF/Mach-O/shellcode) start with other magic bytes.
+    """
+    try:
+        with sample.open("rb") as f:
+            for byte in iter(lambda: f.read(1), b""):
+                if not byte.strip():
+                    continue
+                return byte == b"{"
+    except OSError:
+        return False
+    return False
+
+
+def expand_all_types(types) -> List[str]:
+    """
+    Expand the "all" pseudo-type in --string-type/--no-string-type values
+    into every concrete string type, preserving order and de-duplicating.
+    """
+    expanded = []
+    for t in types:
+        if t == "all":
+            candidates = [st.value for st in StringType]
+        else:
+            candidates = [t]
+        for c in candidates:
+            if c not in expanded:
+                expanded.append(c)
+    return expanded
+
+
 def get_default_root() -> Path:
     """
     get the file system path to the default resources directory.
@@ -69,11 +105,15 @@ def main(argv=None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
-    parser = make_parser(argv)
+    parser = make_parser()
     try:
+        if not argv:
+            # no arguments: print the full option list and exit with code 1
+            parser.print_help()
+            return 1
         args = parser.parse_args(args=argv)
         if args.enabled_types and args.disabled_types:
-            parser.error("--no and --only arguments are not allowed together")
+            parser.error("--string-type and --no-string-type arguments are not allowed together")
     except ArgumentValueError as e:
         print(e)
         return -1
@@ -99,8 +139,8 @@ def main(argv=None) -> int:
     sample = Path(args.sample.name)
     args.sample.close()
 
-    disabled = list(args.disabled_types or [])
-    enabled = list(args.enabled_types or [])
+    disabled = expand_all_types(list(args.disabled_types or []))
+    enabled = expand_all_types(list(args.enabled_types or []))
 
     if args.functions:
         if is_string_type_enabled(StringType.STATIC, disabled, enabled):
@@ -108,17 +148,17 @@ def main(argv=None) -> int:
         if StringType.STATIC.value not in disabled:
             disabled.append(StringType.STATIC.value)
 
-    # layout/tags: temporary dedicated flags (not --no string types); see issue #1348
+    # layout/tags are always on: automatic and detected from the sample content
     analysis = Analysis(
         enable_static_strings=is_string_type_enabled(StringType.STATIC, disabled, enabled),
         enable_stack_strings=is_string_type_enabled(StringType.STACK, disabled, enabled),
         enable_tight_strings=is_string_type_enabled(StringType.TIGHT, disabled, enabled),
         enable_decoded_strings=is_string_type_enabled(StringType.DECODED, disabled, enabled),
-        enable_layout=not args.no_layout,
-        enable_tags=not args.no_tags,
+        enable_layout=True,
+        enable_tags=True,
     )
 
-    if args.load:
+    if is_results_document(sample):
         try:
             results = load(sample, analysis, args.functions, args.min_length)
         except floss.results.InvalidResultsFile as e:

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -24,7 +24,7 @@ import os
 import sys
 import hashlib
 from time import time
-from typing import Set, List, Optional
+from typing import Set, List, Optional, Tuple
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -219,10 +219,11 @@ def _try_layout_static(
     buf: bytes,
     min_length: int,
     enable_tags: bool,
-) -> Optional[ResultLayout]:
+) -> Tuple[Optional[ResultLayout], float]:
     """
     Quantum-style layout extract when PE/ELF/Mach-O parse succeeds.
-    Returns serializable ResultLayout, or None to fall back to classic statics.
+    Returns serializable ResultLayout (or None to fall back to classic statics)
+    along with the elapsed seconds spent in the tag database matching step.
 
     Any failure after a structured layout is detected (extract/tag/structures/DB)
     also returns None so default-on layout cannot crash the whole run.
@@ -232,26 +233,29 @@ def _try_layout_static(
     from floss.ranges import Slice
     from floss.layout.extract import extract_layout_strings
 
+    tags_elapsed = 0.0
     try:
         file_slice = Slice.from_bytes(buf=buf)
         live = compute_layout(file_slice)
 
         if not is_structured_layout(live.name):
             logger.debug("no structured layout (got %r); using classic static strings", live.name)
-            return None
+            return None, tags_elapsed
 
         extract_layout_strings(live, min_length)
         # tag_strings always converts ExtractedString → TaggedString (needed for mark_structures)
         taggers = load_databases() if enable_tags else []
+        tags_t0 = time()
         live.tag_strings(taggers)
+        tags_elapsed = get_runtime_diff(tags_t0)
         live.mark_structures()
         if enable_tags:
             remove_false_positive_lib_strings(live)
 
-        return ResultLayout.from_layout(live)
+        return ResultLayout.from_layout(live), tags_elapsed
     except Exception as e:
         logger.warning("layout-aware static analysis failed; using classic statics: %s", e)
-        return None
+        return None, tags_elapsed
 
 
 def analyze(options: Options) -> Optional[ResultDocument]:
@@ -373,10 +377,13 @@ def analyze(options: Options) -> Optional[ResultDocument]:
     if results.analysis.enable_static_strings:
         logger.info("extracting static strings")
         layout_doc: Optional[ResultLayout] = None
+        layout_tags_elapsed = 0.0
         # only layout/tag work for static_strings runtime — not language ID or the TTY prompt above
         layout_t0 = time()
         if analysis.enable_layout:
-            layout_doc = _try_layout_static(sample_buf, options.min_length, analysis.enable_tags)
+            layout_doc, layout_tags_elapsed = _try_layout_static(sample_buf, options.min_length, analysis.enable_tags)
+            results.metadata.runtime.layout = get_runtime_diff(layout_t0)
+            results.metadata.runtime.tags = layout_tags_elapsed
 
         if layout_doc is not None:
             results.layout = layout_doc

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -358,8 +358,6 @@ def render(results: floss.results.ResultDocument, verbose, disable_headers, colo
     console = Console(file=io.StringIO(), color_system=get_color(color), highlight=False, soft_wrap=True)
 
     # layout-aware path: no classic meta table (quantum-style)
-    # TODO(#1348): --load + --no-layout still hits this branch when the JSON
-    # already contains a layout tree (load does not clear results.layout).
     if results.layout is not None and results.analysis.enable_static_strings:
         layout_view = hide_strings_by_rules(results.layout, DEFAULT_TAG_RULES)
         render_strings(console, layout_view, DEFAULT_TAG_RULES)

--- a/floss/results.py
+++ b/floss/results.py
@@ -244,6 +244,8 @@ class Runtime:
     vivisect: float = 0.0
     find_features: float = 0.0
     static_strings: float = 0.0
+    layout: float = 0.0
+    tags: float = 0.0
     language_strings: float = 0.0
     stack_strings: float = 0.0
     decoded_strings: float = 0.0
@@ -283,7 +285,7 @@ STRING_TYPE_FIELDS = {
 @dataclass
 class Metadata:
     file_path: str
-    # sample identity for consumers (path + content hashes); hashes empty when unknown (e.g. --load of old JSON)
+    # sample identity for consumers (path + content hashes); hashes empty when unknown (e.g. loaded old JSON)
     md5: str = ""
     sha1: str = ""
     sha256: str = ""
@@ -347,10 +349,6 @@ def load(sample: Path, analysis: Analysis, functions: List[int], min_length: int
     logger.debug("loading results document: %s", str(sample))
     results = read(sample)
     results.metadata.file_path = f"{sample}\n{results.metadata.file_path}"
-    # TODO(#1348): apply enable_layout / enable_tags from ``analysis`` on load.
-    # Today only string-type flags are applied (check_set_string_types). A JSON
-    # saved with a layout tree still renders layout UI under ``floss --load``
-    # even when the user passes --no-layout (results.layout is not cleared).
     check_set_string_types(results, analysis)
     if functions:
         filter_functions(results, functions)
@@ -378,7 +376,9 @@ def read(sample: Path) -> ResultDocument:
 def check_set_string_types(results: ResultDocument, wanted_analysis: Analysis) -> None:
     for string_type in STRING_TYPE_FIELDS:
         if getattr(wanted_analysis, string_type) and not getattr(results.analysis, string_type):
-            logger.warning(f"{string_type} not in loaded data, use --only/--no to enable/disable type(s)")
+            logger.warning(
+                f"{string_type} not in loaded data, use --string-type/--no-string-type to enable/disable type(s)"
+            )
         setattr(results.analysis, string_type, getattr(wanted_analysis, string_type))
 
 

--- a/scripts/analysis/bulk_analyze.py
+++ b/scripts/analysis/bulk_analyze.py
@@ -113,7 +113,6 @@ def main():
                             sys.executable,
                             "-m",
                             "floss.main",
-                            "--load",
                             str(json_output_path),
                         ]
                         if args.quiet:
@@ -153,7 +152,6 @@ def main():
                 sys.executable,
                 "-m",
                 "floss.main",
-                "--load",
                 str(json_output_path),
             ]
             if args.quiet:

--- a/scripts/tags/build_oss_db.py
+++ b/scripts/tags/build_oss_db.py
@@ -1099,7 +1099,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--output-dir",
         type=pathlib.Path,
-        default=pathlib.Path(__file__).resolve().parents[2] / "floss" / "qs" / "db" / "data" / "oss",
+        default=pathlib.Path(__file__).resolve().parents[2] / "floss" / "tags" / "data" / "oss",
         help="directory for generated .jsonl.gz files and metrics",
     )
     parser.add_argument(

--- a/scripts/tags/query_string.py
+++ b/scripts/tags/query_string.py
@@ -12,21 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import logging
-import pathlib
 import argparse
 
+from floss.tags import data_root
 from floss.tags.gp import StringGlobalPrevalence, StringGlobalPrevalenceDatabase
 
 logger = logging.getLogger(__name__)
 
 
 def load_db_gp():
-    gpfile = os.path.join(os.path.dirname(__file__), "..", "..", "floss", "qs", "db", "data", "gp", "gp.jsonl.gz")
-    compress = gpfile.endswith(".gz")
-    return StringGlobalPrevalenceDatabase.from_file(pathlib.Path(gpfile), compress=compress)
+    gpfile = data_root() / "gp" / "gp.jsonl.gz"
+    compress = gpfile.suffix == ".gz"
+    return StringGlobalPrevalenceDatabase.from_file(gpfile, compress=compress)
 
 
 def query_string(string) -> StringGlobalPrevalence:

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -22,12 +22,12 @@ from floss.cli import StringType
 
 def test_functions(exefile):
     # 0x1111111 is not a function
-    assert floss.main.main([exefile, "--function", "0x1111111"]) == -1
+    assert floss.main.main([exefile, "--analyze-functions", "0x1111111"]) == -1
 
     # ok
-    assert floss.main.main([exefile, "--function", "0x401560"]) == 0
-    assert floss.main.main([exefile, "--function", "0x401560"]) == 0
-    assert floss.main.main([exefile, "--function", "0x401560", "0x401000"]) == 0
+    assert floss.main.main([exefile, "--analyze-functions", "0x401560"]) == 0
+    assert floss.main.main([exefile, "--analyze-functions", "0x401560"]) == 0
+    assert floss.main.main([exefile, "--analyze-functions", "0x401560", "0x401000"]) == 0
 
 
 def test_shellcode(scfile):
@@ -40,7 +40,7 @@ def test_shellcode(scfile):
 
 
 @pytest.mark.parametrize("type_", [t.value for t in StringType])
-@pytest.mark.parametrize("analysis", ("--only", "--no"))
+@pytest.mark.parametrize("analysis", ("--string-type", "--no-string-type"))
 def test_args_analysis_type(exefile, analysis, type_):
     assert (
         floss.main.main(
@@ -54,10 +54,17 @@ def test_args_analysis_type(exefile, analysis, type_):
     )
 
 
-@pytest.mark.parametrize("flag", ("--no-layout", "--no-tags"))
-def test_args_layout_tag_product_flags(exefile, flag):
-    """Product toggles for layout/tags (not mixed into --no string types)."""
-    assert floss.main.main([exefile, flag, "--no", "stack", "tight", "decoded", "-q"]) == 0
+def test_args_string_type_all(exefile):
+    assert floss.main.main([exefile, "--string-type", "all"]) == 0
+
+
+def test_args_no_string_type_all(exefile):
+    # excluding every string type leaves nothing to extract; exits cleanly
+    assert floss.main.main([exefile, "--no-string-type", "all", "-q"]) == 0
+
+
+def test_args_analysis_type_conflict(exefile):
+    assert floss.main.main([exefile, "--string-type", "stack", "--no-string-type", "tight"]) == -1
 
 
 def test_no_layout_yields_classic_static(exefile):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -2,7 +2,7 @@ import textwrap
 
 import floss.main
 
-# floss --no static -j tests/data/src/decode-in-place/bin/test-decode-in-place.exe
+# floss --no-string-type static -j tests/data/src/decode-in-place/bin/test-decode-in-place.exe
 RESULTS = textwrap.dedent("""
 {
     "analysis": {
@@ -94,7 +94,6 @@ def test_load(tmp_path):
     assert (
         floss.main.main(
             [
-                "-l",
                 str(d.joinpath(p)),
             ]
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,12 +21,26 @@ import floss.main
 
 
 def test_main_help():
-    for help_str in ("-h", "-H"):
+    for help_str in ("-h", "--help"):
         # via https://medium.com/python-pandemonium/testing-sys-exit-with-pytest-10c6e5f7726f
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             floss.main.main([help_str])
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 0
+
+
+def test_main_version():
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        floss.main.main(["--version"])
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 0
+
+
+def test_main_no_args_prints_help_and_exits_1(capsys):
+    assert floss.main.main([]) == 1
+    out = capsys.readouterr().out
+    assert "usage:" in out
+    assert "--analyze-functions" in out
 
 
 def test_main(exefile):


### PR DESCRIPTION
# Migration spec batch 1: CLI cleanup and runtime metrics

## Summary

This change implements the first batch of the FLOSS migration development spec.

## Task list

- [x] Point the tag scripts at the current tag database location.
- [x] Add the layout and tags runtime timing fields to the results document.
- [x] Record the elapsed time of the layout and tag steps in the pipeline.
- [x] Define the help, version, and no-argument behavior.
- [x] Remove the `--no-layout` and `--no-tags` flags.
- [x] Remove the `--load` flag and detect JSON results documents automatically.
- [x] Remove the `--no` and `--only` flags.
- [x] Add the `--string-type` and `--no-string-type` flags with mutual exclusion.
- [x] Rename `--functions` to `--analyze-functions`.
- [ ] Move the string render function into the default render module.
- [ ] Remove the classic view and the obsolete classic helpers.
- [ ] Add centered headings for the stack, tight, and decoded string sections.
- [ ] Add the `--columns` option for column visibility.
- [ ] Add the `--section` and `--no-section` flags.
- [ ] Add the `--structure` and `--no-structure` flags.
- [ ] Add the `--tag` and `--no-tag` flags.
- [ ] Add the `--interesting` shortcut to exclude the noisy tags.
- [ ] Add the `--query` flag to filter strings by content.
- [ ] Add the `--max-strings` flag to cap the strings per section.
- [ ] Emit the full results document as JSON with sorted keys.
- [ ] Add the `--summary` output.
- [ ] Emit structured JSON errors in JSON mode.
- [ ] Add the analysis cache module.
- [ ] Compute the cache key from the sample content hash and the tool version.
- [ ] Store the results document atomically in the cache.
- [ ] Load a valid cached document and skip analysis.
- [ ] Support the environment variables for the cache directory and the cache switch.
- [ ] Drop an invalid cache entry and re-analyze.
