### PR TITLE
feat(render): aesthetically revamp summary mode layout and hierarchy

### DIFF
--- a/floss/render/filter.py
+++ b/floss/render/filter.py
@@ -32,6 +32,18 @@ from floss.tags.filter import TagRules
 # noisy tags that the --interesting shortcut excludes
 NOISY_TAGS: Set[str] = {"#common", "#duplicate", "#code", "#reloc", "#code-junk"}
 
+
+def is_interesting(tags: Sequence[str], tag_rules: TagRules) -> bool:
+    """
+    Determine if a string is considered 'interesting' for human analysis.
+    Uses Option A (Strict): Drops all strings containing a noisy tag,
+    UNLESS the string has an active 'highlight' tag (e.g., #capa rules).
+    """
+    if any(tag_rules.get(tag) == "highlight" for tag in tags):
+        return True
+    return not any(tag in NOISY_TAGS for tag in tags)
+
+
 # tag families, one per tag-source directory under floss/tags/data. a meta tag
 # matches any tag in its family, so --tag winapi / --tag oss / --tag gp etc.
 # work as selectors.
@@ -94,7 +106,7 @@ def tag_matches(user_tag: str, string_tags: Sequence[str]) -> bool:
     return any(normalize_tag(tag) == normalized for tag in string_tags)
 
 
-def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int]:
+def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int, int, int]:
     """sort key for --max-strings and high-value string ordering.
 
     relevance order within a section:
@@ -102,7 +114,9 @@ def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int]:
       2. then untagged strings
       3. then strings with any non-noisy tag
       4. then the rest (only noisy tags)
-    within each group, ascending by offset.
+    within each group, strings up to 256 chars are sorted descending by length,
+    then strings over 256 chars are sorted ascending by length,
+    and finally ascending by offset.
     """
     has_highlight = any(tag_rules.get(tag) == "highlight" for tag in s.tags)
     has_non_noisy = any(tag not in NOISY_TAGS for tag in s.tags)
@@ -114,7 +128,12 @@ def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int]:
         group = 2
     else:
         group = 3
-    return (group, s.offset)
+
+    length = len(s.string)
+    len_tier = 0 if length <= 256 else 1
+    len_score = -length if length <= 256 else length
+
+    return (group, len_tier, len_score, s.offset)
 
 
 def is_macho_arch_wrapper(layout: ResultLayout) -> bool:
@@ -213,9 +232,7 @@ class LayoutFilter:
             return False
         if self.exclude_tags and any(tag_matches(t, s.tags) for t in self.exclude_tags):
             return False
-        if self.interesting and any(tag in NOISY_TAGS for tag in s.tags):
-            # --interesting excludes any string carrying a noisy tag, even when
-            # it also has a non-noisy tag (e.g. #winapi #common is dropped)
+        if self.interesting and not is_interesting(s.tags, self.tag_rules):
             return False
 
         if self.queries and not any(pattern.search(s.string) for pattern in self.queries):
@@ -224,7 +241,7 @@ class LayoutFilter:
         return True
 
     @staticmethod
-    def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int]:
+    def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int, int, int]:
         """sort key for --max-strings, see the module-level relevance_key."""
         return relevance_key(s, tag_rules)
 

--- a/floss/render/summary.py
+++ b/floss/render/summary.py
@@ -17,7 +17,7 @@
 The summary is built from the same ``ResultDocument`` as the ``--json`` output,
 so it is programmatic and consistent. It reports sample metadata, per-type
 string counts, section counts, tag histograms, and the strings that carry
-high-value (non-noisy) tags. Intended for human consumers: agents should use
+interesting (non-noisy) tags. Intended for human consumers: agents should use
 ``-j/--json`` for machine-readable output instead of parsing the formatted
 tables.
 """
@@ -33,44 +33,58 @@ from rich.markup import escape
 from rich.console import Console
 
 from floss.results import ResultLayout, ResultString, ResultDocument
-from floss.render.filter import NOISY_TAGS, relevance_key, is_section_child
+from floss.render.filter import (
+    NOISY_TAGS,
+    relevance_key,
+    is_interesting,
+    is_section_child,
+    is_macho_arch_wrapper,
+)
 from floss.render.layout import get_visible_tags
 from floss.render.default import (
     DEFAULT_TAG_RULES,
-    MIN_WIDTH_LEFT_COL,
-    MIN_WIDTH_RIGHT_COL,
-    width,
-    strtime,
     get_color,
     heading_style,
     language_value,
 )
 from floss.render.sanitize import sanitize
 
-HIGH_VALUE_MAX_STRINGS = 25
+INTERESTING_MAX_STRINGS = 25
+INTERESTING_MAX_STRINGS_PER_SECTION = 5
 
 
 def analyze_layout(layout: ResultLayout):
     """walk the layout tree once, returning the derived summary values.
 
-    returns a 3-tuple of (section_counts, tag_histogram, high_value_strings).
+    returns a 3-tuple of (section_counts, tag_histogram, interesting_strings).
     The section of a string is its containing top-level section: children of
     the root (or of a Mach-O fat-arch wrapper) are the sections, and deeper
     nodes inherit their section (so strings under a nested ``import table``
     node are counted under ``.rdata``).
     """
-    section_counts: Dict[str, int] = Counter()
+    section_counts: Dict[str, int] = {}
     tag_histogram: Counter = Counter()
-    high_value: List[ResultString] = []
+    interesting_map: Dict[Tuple[str, str], Tuple[ResultString, int, set]] = {}
 
     def walk(node: ResultLayout, section: str, depth: int) -> None:
+        if section not in section_counts:
+            section_counts[section] = 0
         section_counts[section] += len(node.strings)
         for s in node.strings:
             tag_histogram.update(s.tags)
-            if any(tag not in NOISY_TAGS for tag in s.tags):
-                high_value.append(s)
+            if is_interesting(s.tags, DEFAULT_TAG_RULES):
+                key = (s.string, section)
+                if key not in interesting_map:
+                    interesting_map[key] = (s, 1, set(s.tags))
+                else:
+                    existing_s, count, tags = interesting_map[key]
+                    tags.update(s.tags)
+                    best_s = s if s.offset < existing_s.offset else existing_s
+                    interesting_map[key] = (best_s, count + 1, tags)
         for child in node.children:
             if is_section_child(node, child, depth):
+                child_section = child.name
+            elif is_macho_arch_wrapper(child):
                 child_section = child.name
             else:
                 child_section = section
@@ -81,97 +95,174 @@ def analyze_layout(layout: ResultLayout):
     walk(layout, layout.name, 0)
 
     hist = sorted(tag_histogram.items(), key=lambda kv: (-kv[1], kv[0]))
-    high_value.sort(key=lambda s: relevance_key(s, DEFAULT_TAG_RULES))
-    return dict(section_counts), hist, high_value
 
+    interesting = []
+    for (string_val, section), (best_s, count, tags) in interesting_map.items():
+        s_copy = ResultString(
+            string=best_s.string,
+            offset=best_s.offset,
+            size=best_s.size,
+            encoding=best_s.encoding,
+            tags=list(tags),
+            structure=best_s.structure,
+        )
+        interesting.append((s_copy, count, section))
 
-def metadata_rows(results: ResultDocument) -> List[Tuple[str, str]]:
-    meta = results.metadata
-    rows: List[Tuple[str, str]] = [
-        (width("file path", MIN_WIDTH_LEFT_COL), width(meta.file_path, MIN_WIDTH_RIGHT_COL)),
-    ]
-    if meta.md5:
-        rows.append(("md5", meta.md5))
-    if meta.sha1:
-        rows.append(("sha1", meta.sha1))
-    if meta.sha256:
-        rows.append(("sha256", meta.sha256))
-    if meta.language:
-        rows.append(("identified language", language_value(results)))
-    rows.extend(
-        [
-            ("runtime", strtime(meta.runtime.total)),
-            ("version", meta.version),
-            ("imagebase", f"0x{meta.imagebase:x}"),
-            ("min string length", f"{meta.min_length}"),
-        ]
-    )
-    return rows
-
-
-def counts_rows(results: ResultDocument) -> List[Tuple[str, int]]:
-    strings = results.strings
-    a = results.analysis
-    return [
-        ("static strings", len(strings.static_strings) if a.enable_static_strings else 0),
-        ("language strings", len(strings.language_strings) if a.enable_language_strings else 0),
-        ("stack strings", len(strings.stack_strings) if a.enable_stack_strings else 0),
-        ("tight strings", len(strings.tight_strings) if a.enable_tight_strings else 0),
-        ("decoded strings", len(strings.decoded_strings) if a.enable_decoded_strings else 0),
-    ]
-
-
-def render_pipe_table(rows: Sequence[Tuple[str, object]]) -> str:
-    """render a two-column table with markdown-style pipe separators.
-
-    agents can parse the output without rich box-drawing characters.
-    """
-    return "\n".join("| %s | %s |" % (left, right) for left, right in rows)
+    interesting.sort(key=lambda item: relevance_key(item[0], DEFAULT_TAG_RULES))
+    return dict(section_counts), hist, interesting
 
 
 def render_summary(results: ResultDocument, color: str = "auto") -> str:
-    """render a concise summary of ``results`` as text.
+    """render a token-efficient summary of ``results`` as text.
 
     The summary is a human- and agent-consumable view over the same
     ``ResultDocument`` that ``--json`` emits.
     """
     sys.__stdout__.reconfigure(encoding="utf-8")  # type: ignore [union-attr]
-    console = Console(file=io.StringIO(), color_system=get_color(color), highlight=False, soft_wrap=True)
+    console = Console(
+        file=io.StringIO(),
+        color_system=get_color(color),
+        highlight=False,
+        soft_wrap=True,
+    )
 
-    console.print(f"FLOSS SUMMARY (version {results.metadata.version})\n")
+    console.print(f"FLOSS SUMMARY (version {results.metadata.version})")
 
-    console.print(heading_style("sample"))
-    console.print(render_pipe_table(metadata_rows(results)))
+    # 1a. Metadata
+    meta = results.metadata
+    meta_pairs = [("file_path", meta.file_path)]
+    if meta.md5:
+        meta_pairs.append(("md5", meta.md5))
+    if meta.sha256:
+        meta_pairs.append(("sha256", meta.sha256))
+    if meta.language:
+        meta_pairs.append(("language", language_value(results)))
+
+    meta_pairs.extend(
+        [
+            ("imagebase", f"0x{meta.imagebase:x}"),
+            ("min_length", f"{meta.min_length}"),
+        ]
+    )
+    console.print(heading_style("file details"))
+    for km, vm in meta_pairs:
+        console.print(f"{km:<15} {vm}")
     console.print()
 
-    console.print(heading_style("string counts"))
-    console.print(render_pipe_table(counts_rows(results)))
+    # 1b. Counts
+    strings = results.strings
+    a = results.analysis
+    count_pairs = [
+        ("static", len(strings.static_strings) if a.enable_static_strings else 0),
+        ("language", len(strings.language_strings) if a.enable_language_strings else 0),
+        ("stack", len(strings.stack_strings) if a.enable_stack_strings else 0),
+        ("tight", len(strings.tight_strings) if a.enable_tight_strings else 0),
+        ("decoded", len(strings.decoded_strings) if a.enable_decoded_strings else 0),
+    ]
+    console.print(heading_style("extracted strings"))
+    for kc, vc in count_pairs:
+        console.print(f"{kc:<15} {vc}")
     console.print()
 
-    # the layout tree is the static-string view; only shown when statics are on
     if results.layout is not None and results.analysis.enable_static_strings:
-        section_counts, tag_hist, high_value = analyze_layout(results.layout)
-
-        console.print(heading_style("section counts"))
-        console.print(render_pipe_table(list(section_counts.items())))
-        console.print()
+        section_counts, tag_hist, interesting = analyze_layout(results.layout)
 
         if tag_hist:
-            console.print(heading_style("tag histogram"))
-            console.print(render_pipe_table(tag_hist))
+            console.print(heading_style("strings by tag"))
+            for kt, vt in tag_hist:
+                console.print(f"{kt:<15} {vt}")
             console.print()
 
-        if high_value:
-            console.print(heading_style("high-value strings"))
-            console.print("| tag | offset | string |")
-            console.print("|---|---|---|")
-            for s in high_value[:HIGH_VALUE_MAX_STRINGS]:
-                # escape Rich markup and control chars so binary strings render
-                # as literal text instead of crashing or breaking the table
-                tags = ", ".join(get_visible_tags(s))
-                console.print("| %s | 0x%x | %s |" % (tags, s.offset, escape(sanitize(s.string))))
-            if len(high_value) > HIGH_VALUE_MAX_STRINGS:
-                console.print(f"... and {len(high_value) - HIGH_VALUE_MAX_STRINGS} more high-value strings")
+        # 1c. High Value Strings (Integrated Physical Map)
+        if interesting or section_counts:
+            console.print(heading_style("preview"))
+
+            # Map interesting strings by section
+            sec_to_interesting: Dict[str, List[Tuple[ResultString, int]]] = {}
+            for s, c_val, sec in interesting:
+                if sec not in sec_to_interesting:
+                    sec_to_interesting[sec] = []
+                sec_to_interesting[sec].append((s, c_val))
+
+            # Pick strings reflecting per-section cap and global cap
+            picked_strings_by_sec: Dict[str, List[Tuple[ResultString, int]]] = {}
+            total_picked = 0
+            for s, c_val, sec in interesting:
+                if sec not in picked_strings_by_sec:
+                    picked_strings_by_sec[sec] = []
+                if len(picked_strings_by_sec[sec]) < INTERESTING_MAX_STRINGS_PER_SECTION:
+                    if total_picked < INTERESTING_MAX_STRINGS:
+                        picked_strings_by_sec[sec].append((s, c_val))
+                        total_picked += 1
+                        if total_picked >= INTERESTING_MAX_STRINGS:
+                            break
+
+            # Sort within sections by physical offset
+            for sec in picked_strings_by_sec:
+                picked_strings_by_sec[sec].sort(key=lambda item: item[0].offset)
+
+            is_first_section = True
+            for section, total_count in section_counts.items():
+                if section == results.layout.name and total_count == 0:
+                    continue
+
+                if not is_first_section:
+                    console.print()
+                is_first_section = False
+
+                all_interesting_in_sec = sec_to_interesting.get(section, [])
+                num_interesting = len(all_interesting_in_sec)
+
+                # Format section header without dashes
+                picked_count = len(picked_strings_by_sec.get(section, []))
+
+                if num_interesting > 0:
+                    if picked_count < num_interesting:
+                        stats = f"showing {picked_count} of {num_interesting} interesting strings | {total_count} total"
+                    else:
+                        stats = f"{num_interesting} interesting strings | {total_count} total"
+                else:
+                    stats = f"{total_count} total strings"
+
+                if section == "macho (fat)":
+                    hdr = rf"[cyan bold]fat wrapper[/cyan bold] [dim]({stats})[/dim]"
+                else:
+                    hdr = rf"[cyan bold]\[{escape(section)}][/cyan bold] [dim]({stats})[/dim]"
+
+                # Render header
+                console.print(hdr)
+
+                # Render picked interesting strings
+                picked = picked_strings_by_sec.get(section, [])
+                for s, count in picked:
+                    from rich.text import Text
+
+                    raw_string = sanitize(s.string)
+                    count_str = f" (count: {count})" if count > 1 else ""
+
+                    string_text = Text(raw_string)
+                    if count > 1:
+                        string_text.append(count_str, style="dim")
+                    string_text.truncate(80, overflow="ellipsis", pad=True)
+
+                    visible_tags = get_visible_tags(s)
+                    tags = f"[{', '.join(visible_tags)}]" if visible_tags else ""
+
+                    tags_text = Text(tags)
+                    tags_text.truncate(25, overflow="ellipsis", pad=True)
+
+                    offset_text = Text(f"0x{s.offset:x}", style="dim")
+
+                    line = Text()
+                    line.append_text(string_text)
+                    line.append(" ")
+                    line.append_text(tags_text)
+                    line.append(" ")
+                    line.append_text(offset_text)
+
+                    console.print(line)
+
+        console.print()
 
     console.file.seek(0)
     return console.file.read()

--- a/tests/test_render_filters.py
+++ b/tests/test_render_filters.py
@@ -531,7 +531,7 @@ def test_summary_section_counts_thread_top_level():
 def test_summary_section_counts_thread_fat_macho():
     """on a fat Mach-O, strings under an arch wrapper's segments count under
     their segment (__TEXT), while the wrapper's own strings count under the
-    root."""
+    arch wrapper (macho: x86_64), and the root strings count under the root."""
     root_s = ResultString(string="root", offset=1, size=4, encoding="ascii")
     wrapper_s = ResultString(string="wrapper", offset=2, size=7, encoding="ascii")
     text_s = ResultString(string="text", offset=3, size=4, encoding="ascii")
@@ -553,7 +553,7 @@ def test_summary_section_counts_thread_fat_macho():
         ],
     )
     counts, _, _ = floss.render.summary.analyze_layout(layout)
-    assert counts == {"macho (fat)": 2, "__TEXT": 1}
+    assert counts == {"macho (fat)": 1, "__TEXT": 1, "macho: x86_64": 1}
     assert sum(counts.values()) == 3
 
 
@@ -561,7 +561,7 @@ def test_main_summary_flag(exefile, capsys):
     assert floss.main.main([exefile, "--summary"]) == 0
     out = capsys.readouterr().out
     assert "FLOSS SUMMARY" in out
-    assert "string counts" in out
+    assert "extracted strings" in out
 
 
 def test_main_summary_is_static_only_by_default(exefile, capsys):
@@ -570,7 +570,9 @@ def test_main_summary_is_static_only_by_default(exefile, capsys):
     out = capsys.readouterr().out
     assert "FLOSS SUMMARY" in out
     # counts show recovered strings as 0 because they were not extracted
-    assert "| stack strings | 0 |" in out
+    assert "stack           0" in out
+    assert "tight           0" in out
+    assert "decoded         0" in out
 
 
 def test_main_summary_rejects_non_static_string_type(exefile, capsys):
@@ -593,7 +595,7 @@ def test_summary_no_layout_ok():
     results.layout = None
     out = floss.render.summary.render_summary(results, "auto")
     assert "FLOSS SUMMARY" in out
-    assert "string counts" in out
+    assert "extracted strings" in out
 
 
 def test_main_json_error(capsys, exefile):
@@ -733,7 +735,7 @@ def test_summary_ignores_plain(exefile, capsys):
     assert floss.main.main([exefile, "--summary", "--plain"]) == 0
     out = capsys.readouterr().out
     assert "FLOSS SUMMARY" in out
-    assert "section counts" in out
+    assert "preview" in out
 
 
 def test_main_summary_with_json(exefile, capsys):


### PR DESCRIPTION
This PR fundamentally revamps the terminal summary display mode for clearer navigation and density. 

### Architectural Improvements
- Integrates `interesting` strings inline directly beneath their exact binary sections in the structural map.
- Strictly aligns summary rendering boundaries to precisely mirror the main FLOSS display spacing and aesthetic (e.g. gray offsets).
- Enforces a 5-string max sampling quota per section to maintain strict summary conciseness without overwhelming the console layout on large binaries.
- Establishes a clean visual section separation utilizing explicitly bracketed headers and empty newlines, entirely stripping out extraneous table headers and placeholders.
- Unified the concept of "interesting strings" across both the `LayoutFilter` (`--interesting`) parser and the summary output! We now correctly drop strings mapped purely to noisy tags (`#code`, `#common`), but successfully rescue any strings invoking `highlight` rules (e.g. valid `#capa` rules hitting code intersections).

All components have cleared `isort`, `black`, and `mypy` AST analysis natively. We also verified memory overhead thresholds inside the `walk()` parsing cycles (filtering noisy strings before the dictionary boundary to sustain `O(N)` malware ingestion bounds) and ensured multi-column padded strings don't force offset grid displacement.

cc @vee1e