### PR TITLE
Folding of QS CLI - Part 3

### DIFF
--- a/floss/cache.py
+++ b/floss/cache.py
@@ -64,20 +64,20 @@ _ENABLED_VALUES = ("1", "true", "yes", "y")
 def cache_enabled() -> bool:
     """Whether result caching is enabled.
 
-    ``FLOSS_CACHE_ENABLE`` disables caching when set to 0 (or false/no/n);
-    caching is enabled by default.
+    ``FLOSS_CACHE_ENABLE`` disables caching when set to 0 (or false/no/n,
+    case-insensitive); caching is enabled by default.
     """
-    return os.environ.get(ENV_CACHE_ENABLE, "1") not in _DISABLED_VALUES
+    return os.environ.get(ENV_CACHE_ENABLE, "1").lower() not in _DISABLED_VALUES
 
 
 def cache_refresh() -> bool:
     """Whether the current run should bypass the cache and overwrite its entry.
 
-    ``FLOSS_CACHE_REFRESH=1`` (or true/yes/y) forces a re-analysis: the cached
-    document is ignored and the fresh result is stored on top of it. Unset by
-    default.
+    ``FLOSS_CACHE_REFRESH=1`` (or true/yes/y, case-insensitive) forces a
+    re-analysis: the cached document is ignored and the fresh result is stored
+    on top of it. Unset by default.
     """
-    return os.environ.get(ENV_CACHE_REFRESH, "") in _ENABLED_VALUES
+    return os.environ.get(ENV_CACHE_REFRESH, "").lower() in _ENABLED_VALUES
 
 
 def get_cache_dir() -> Path:

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -103,15 +103,28 @@ def load(cache_dir: Path, key: str, sha256: str, version: str) -> Optional[Resul
         doc = ResultDocument.parse_file(path)
     except (OSError, UnicodeDecodeError, ValueError) as e:
         logger.warning("dropping invalid cache entry %s: %s", path.name, e)
-        path.unlink(missing_ok=True)
+        _drop_cache_entry(path)
         return None
 
     if doc.metadata.sha256 != sha256 or doc.metadata.version != version:
         logger.warning("dropping stale cache entry %s (checksum/version mismatch)", path.name)
-        path.unlink(missing_ok=True)
+        _drop_cache_entry(path)
         return None
 
     return doc
+
+
+def _drop_cache_entry(path: Path) -> None:
+    """Best-effort removal of a stale cache entry; never raises.
+
+    The entry may be held open by another reader or an antivirus scanner (e.g.
+    on Windows), so removal can fail with a PermissionError. Leave it and let
+    the caller continue.
+    """
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as e:
+        logger.warning("could not remove cache entry %s: %s", path.name, e)
 
 
 def store(cache_dir: Path, key: str, doc: ResultDocument) -> bool:
@@ -130,19 +143,33 @@ def store(cache_dir: Path, key: str, doc: ResultDocument) -> bool:
         return False
 
     try:
-        payload = floss.render.json.render(doc)
-        fd, tmp_name = tempfile.mkstemp(dir=str(cache_dir), prefix=f"{key}.", suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(payload)
-            os.replace(tmp_name, cache_file_path(cache_dir, key))
-        finally:
-            if os.path.exists(tmp_name):
-                os.unlink(tmp_name)
+        return _write_atomic(cache_dir, key, floss.render.json.render(doc))
     finally:
         _release_lock(lock_fd, lock_path)
 
-    return True
+
+def _write_atomic(cache_dir: Path, key: str, payload: str) -> bool:
+    """Atomically write ``{key}.json`` into the cache, or False on any OS failure.
+
+    The payload is written to a temporary file in the cache directory and then
+    renamed into place. Cache writes are best-effort: a failure (disk full, the
+    destination held open by an antivirus scanner or another reader, etc.) must
+    not crash the analysis, so it is logged and caching is skipped.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(cache_dir), prefix=f"{key}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp_name, cache_file_path(cache_dir, key))
+        return True
+    except OSError as e:
+        logger.warning("could not store cache entry %s: %s; skipping cache write", key, e)
+        return False
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
 
 
 def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -195,7 +195,7 @@ def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:
     document was built with (shorter strings were dropped at extraction time
     and cannot be recovered). Layout and tags are not part of the match: a
     cached layout/tags document can satisfy a request without them because
-    :func:`materialize` drops the layout and redacts the tags when they are not
+    `materialize()` drops the layout and redacts the tags when they are not
     wanted. The reverse (requesting layout/tags the cache was not built with) is
     a miss.
     """
@@ -299,7 +299,7 @@ def _acquire_lock(lock_path: Path) -> Optional[int]:
 
 
 def _release_lock(fd: int, lock_path: Path) -> None:
-    """Release a lock previously acquired by :func:`_acquire_lock`."""
+    """Release a lock previously acquired by `_acquire_lock()`."""
     if sys.platform == "win32":
         import msvcrt
 

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result-document caching for repeated FLOSS analyses.
+
+The full ResultDocument is cached on first execution and reused on later runs,
+so repeated analyses of the same sample are fast. The cache is keyed by the
+SHA-256 of the sample bytes plus the FLOSS version, and stores the same JSON
+schema emitted by ``--json``.
+
+Caching applies to binary sample analysis only: loading a user-supplied JSON
+document never writes to the cache.
+
+The cache directory defaults to the platform cache directory and can be
+overridden with ``FLOSS_CACHE_DIR``. Caching can be disabled entirely by
+setting ``FLOSS_CACHE_ENABLE=0``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from typing import Optional
+from pathlib import Path
+
+from platformdirs import user_cache_dir
+
+import floss.logging_
+import floss.render.json
+from floss.results import (
+    STRING_TYPE_FIELDS,
+    Analysis,
+    ResultDocument,
+    filter_string_len,
+    check_set_string_types,
+)
+
+logger = floss.logging_.getLogger(__name__)
+
+ENV_CACHE_DIR = "FLOSS_CACHE_DIR"
+ENV_CACHE_ENABLE = "FLOSS_CACHE_ENABLE"
+
+# values that disable caching, so FLOSS_CACHE_ENABLE=0 behaves as documented
+_DISABLED_VALUES = ("0", "false", "no", "n", "")
+
+
+def cache_enabled() -> bool:
+    """Whether result caching is enabled.
+
+    ``FLOSS_CACHE_ENABLE`` disables caching when set to 0 (or false/no/n);
+    caching is enabled by default.
+    """
+    return os.environ.get(ENV_CACHE_ENABLE, "1") not in _DISABLED_VALUES
+
+
+def get_cache_dir() -> Path:
+    """Resolve the analysis cache directory.
+
+    ``FLOSS_CACHE_DIR`` overrides the platform default cache directory:
+      - Linux:   ``$XDG_CACHE_HOME/floss`` (or ``~/.cache/floss``)
+      - macOS:   ``~/Library/Caches/floss``
+      - Windows: ``%LOCALAPPDATA%\\floss\\Cache``
+    """
+    override = os.environ.get(ENV_CACHE_DIR)
+    if override:
+        return Path(override)
+    return Path(user_cache_dir("floss"))
+
+
+def compute_key(sha256: str, version: str) -> str:
+    """The cache key: content-addressed sample hash + FLOSS version."""
+    return f"{sha256}-{version}"
+
+
+def cache_file_path(cache_dir: Path, key: str) -> Path:
+    """The on-disk location of a cache entry: ``{cache_dir}/{key}.json``."""
+    return cache_dir / f"{key}.json"
+
+
+def load(cache_dir: Path, key: str, sha256: str, version: str) -> Optional[ResultDocument]:
+    """Load and validate a cached document, or None on a miss.
+
+    On a parse failure or a checksum or version mismatch the entry is dropped
+    so the caller re-analyzes and stores a fresh document.
+    """
+    path = cache_file_path(cache_dir, key)
+    if not path.is_file():
+        return None
+
+    try:
+        doc = ResultDocument.parse_file(path)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        logger.warning("dropping invalid cache entry %s: %s", path.name, e)
+        path.unlink(missing_ok=True)
+        return None
+
+    if doc.metadata.sha256 != sha256 or doc.metadata.version != version:
+        logger.warning("dropping stale cache entry %s (checksum/version mismatch)", path.name)
+        path.unlink(missing_ok=True)
+        return None
+
+    return doc
+
+
+def store(cache_dir: Path, key: str, doc: ResultDocument) -> bool:
+    """Atomically write a result document to the cache.
+
+    The write is guarded by a lock file so concurrent first runs cannot corrupt
+    the entry. When the lock cannot be acquired, caching is skipped and False is
+    returned (the caller decides how to warn).
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    lock_path = cache_dir / f"{key}.lock"
+    lock_fd = _acquire_lock(lock_path)
+    if lock_fd is None:
+        logger.warning("could not acquire cache lock %s; skipping cache write", lock_path)
+        return False
+
+    try:
+        payload = floss.render.json.render(doc)
+        fd, tmp_name = tempfile.mkstemp(dir=str(cache_dir), prefix=f"{key}.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp_name, cache_file_path(cache_dir, key))
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+    finally:
+        _release_lock(lock_fd, lock_path)
+
+    return True
+
+
+def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:
+    """Whether a cached document satisfies the requested analysis.
+
+    Every string type the user wants enabled must be present in the cached
+    document, the layout/tags preference must match, and the requested
+    ``--minimum-length`` must not be below what the document was built with
+    (shorter strings were dropped at extraction time and cannot be recovered).
+    """
+    for field in STRING_TYPE_FIELDS:
+        if getattr(wanted, field) and not getattr(cached.analysis, field):
+            return False
+
+    if wanted.enable_layout and not cached.analysis.enable_layout:
+        return False
+    if not wanted.enable_layout and cached.layout is not None:
+        return False
+    if wanted.enable_tags and not cached.analysis.enable_tags:
+        return False
+    if not wanted.enable_tags and cached.analysis.enable_tags:
+        return False
+
+    if min_length < cached.metadata.min_length:
+        return False
+
+    return True
+
+
+def materialize(doc: ResultDocument, sample: Path, analysis: Analysis, min_length: int) -> ResultDocument:
+    """Apply the same post-load filtering as loading a user-supplied JSON document.
+
+    Rendering flags (--query, --columns, --max-strings, and the tag and section
+    filters) apply at render time, so they work unchanged on cached results.
+    """
+    doc.metadata.file_path = str(sample)
+    check_set_string_types(doc, analysis)
+    filter_string_len(doc, min_length)
+    return doc
+
+
+def _acquire_lock(lock_path: Path) -> Optional[int]:
+    """Acquire an exclusive lock on the given lock file, non-blocking.
+
+    Returns the open file descriptor when the lock is held, or None when
+    another process holds it.
+    """
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        return None
+
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        return None
+
+    return fd
+
+
+def _release_lock(fd: int, lock_path: Path) -> None:
+    """Release a lock previously acquired by :func:`_acquire_lock`."""
+    if sys.platform == "win32":
+        import msvcrt
+
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    os.close(fd)
+    # the lock is never contended: acquire is non-blocking and skips on failure,
+    # so no other process can be waiting on the file we just released. unlink it
+    # to keep the cache directory clean.
+    try:
+        lock_path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -149,9 +149,11 @@ def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:
     """Whether a cached document satisfies the requested analysis.
 
     Every string type the user wants enabled must be present in the cached
-    document, the layout/tags preference must match, and the requested
+    document, the tags preference must match, and the requested
     ``--minimum-length`` must not be below what the document was built with
     (shorter strings were dropped at extraction time and cannot be recovered).
+    Layout is not part of the match: a cached layout can satisfy a no-layout
+    request because :func:`materialize` drops it when it is not wanted.
     """
     for field in STRING_TYPE_FIELDS:
         if getattr(wanted, field) and not getattr(cached.analysis, field):
@@ -159,8 +161,7 @@ def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:
 
     if wanted.enable_layout and not cached.analysis.enable_layout:
         return False
-    if not wanted.enable_layout and cached.layout is not None:
-        return False
+    # a cached layout can satisfy a no-layout request: materialize() drops it later
     if wanted.enable_tags and not cached.analysis.enable_tags:
         return False
     if not wanted.enable_tags and cached.analysis.enable_tags:
@@ -180,6 +181,8 @@ def materialize(doc: ResultDocument, sample: Path, analysis: Analysis, min_lengt
     """
     doc.metadata.file_path = str(sample)
     check_set_string_types(doc, analysis)
+    if not analysis.enable_layout:
+        doc.layout = None
     filter_string_len(doc, min_length)
     return doc
 

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -149,7 +149,11 @@ def store(cache_dir: Path, key: str, doc: ResultDocument) -> bool:
     the entry. When the lock cannot be acquired, caching is skipped and False is
     returned (the caller decides how to warn).
     """
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning("could not create cache directory %s: %s; skipping cache write", cache_dir, e)
+        return False
 
     lock_path = cache_dir / f"{key}.lock"
     lock_fd = _acquire_lock(lock_path)
@@ -167,11 +171,16 @@ def _write_atomic(cache_dir: Path, key: str, payload: str) -> bool:
     """Atomically write ``{key}.json`` into the cache, or False on any OS failure.
 
     The payload is written to a temporary file in the cache directory and then
-    renamed into place. Cache writes are best-effort: a failure (disk full, the
-    destination held open by an antivirus scanner or another reader, etc.) must
-    not crash the analysis, so it is logged and caching is skipped.
+    renamed into place. Cache writes are best-effort: a failure (disk full, an
+    unwritable cache directory, the destination held open by an antivirus
+    scanner or another reader, etc.) must not crash the analysis, so it is
+    logged and caching is skipped.
     """
-    fd, tmp_name = tempfile.mkstemp(dir=str(cache_dir), prefix=f"{key}.", suffix=".tmp")
+    try:
+        fd, tmp_name = tempfile.mkstemp(dir=str(cache_dir), prefix=f"{key}.", suffix=".tmp")
+    except OSError as e:
+        logger.warning("could not create temporary cache file in %s: %s; skipping cache write", cache_dir, e)
+        return False
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(payload)

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -111,7 +111,12 @@ def load(cache_dir: Path, key: str, sha256: str, version: str) -> Optional[Resul
     so the caller re-analyzes and stores a fresh document.
     """
     path = cache_file_path(cache_dir, key)
-    if not path.is_file():
+    try:
+        if not path.is_file():
+            return None
+    except OSError:
+        # e.g. a locked parent directory makes stat() raise PermissionError;
+        # treat it as a miss so the analysis runs instead of crashing
         return None
 
     try:

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -199,6 +199,11 @@ def _acquire_lock(lock_path: Path) -> Optional[int]:
         if sys.platform == "win32":
             import msvcrt
 
+            # msvcrt.locking cannot lock a byte range past EOF, so ensure the
+            # lock file has at least one byte before taking the lock.
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
             msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
         else:
             import fcntl

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -181,6 +181,22 @@ def materialize(doc: ResultDocument, sample: Path, analysis: Analysis, min_lengt
     """
     doc.metadata.file_path = str(sample)
     check_set_string_types(doc, analysis)
+    doc.analysis.enable_layout = analysis.enable_layout
+    doc.analysis.enable_tags = analysis.enable_tags
+    # mirror a fresh run: a disabled string type is absent from the document,
+    # not merely flagged. a cache hit must not emit data the user excluded.
+    if not analysis.enable_static_strings:
+        doc.strings.static_strings = []
+        doc.layout = None
+    if not analysis.enable_stack_strings:
+        doc.strings.stack_strings = []
+    if not analysis.enable_tight_strings:
+        doc.strings.tight_strings = []
+    if not analysis.enable_decoded_strings:
+        doc.strings.decoded_strings = []
+    if not analysis.enable_language_strings:
+        doc.strings.language_strings = []
+        doc.strings.language_strings_missed = []
     if not analysis.enable_layout:
         doc.layout = None
     filter_string_len(doc, min_length)

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -252,6 +252,9 @@ def materialize(doc: ResultDocument, sample: Path, analysis: Analysis, min_lengt
     if not analysis.enable_tags:
         _clear_tags(doc)
     filter_string_len(doc, min_length)
+    # mirror a fresh run: the requested -n is what the document reports, so
+    # --json does not advertise a looser extraction threshold than it holds
+    doc.metadata.min_length = min_length
     return doc
 
 

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -42,6 +42,7 @@ import floss.render.json
 from floss.results import (
     STRING_TYPE_FIELDS,
     Analysis,
+    ResultLayout,
     ResultDocument,
     filter_string_len,
     check_set_string_types,
@@ -176,11 +177,13 @@ def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:
     """Whether a cached document satisfies the requested analysis.
 
     Every string type the user wants enabled must be present in the cached
-    document, the tags preference must match, and the requested
-    ``--minimum-length`` must not be below what the document was built with
-    (shorter strings were dropped at extraction time and cannot be recovered).
-    Layout is not part of the match: a cached layout can satisfy a no-layout
-    request because :func:`materialize` drops it when it is not wanted.
+    document, and the requested ``--minimum-length`` must not be below what the
+    document was built with (shorter strings were dropped at extraction time
+    and cannot be recovered). Layout and tags are not part of the match: a
+    cached layout/tags document can satisfy a request without them because
+    :func:`materialize` drops the layout and redacts the tags when they are not
+    wanted. The reverse (requesting layout/tags the cache was not built with) is
+    a miss.
     """
     for field in STRING_TYPE_FIELDS:
         if getattr(wanted, field) and not getattr(cached.analysis, field):
@@ -188,10 +191,7 @@ def covers(cached: ResultDocument, wanted: Analysis, min_length: int) -> bool:
 
     if wanted.enable_layout and not cached.analysis.enable_layout:
         return False
-    # a cached layout can satisfy a no-layout request: materialize() drops it later
     if wanted.enable_tags and not cached.analysis.enable_tags:
-        return False
-    if not wanted.enable_tags and cached.analysis.enable_tags:
         return False
 
     if min_length < cached.metadata.min_length:
@@ -226,8 +226,30 @@ def materialize(doc: ResultDocument, sample: Path, analysis: Analysis, min_lengt
         doc.strings.language_strings_missed = []
     if not analysis.enable_layout:
         doc.layout = None
+    if not analysis.enable_tags:
+        _clear_tags(doc)
     filter_string_len(doc, min_length)
     return doc
+
+
+def _clear_tags(doc: ResultDocument) -> None:
+    """Redact tag classifications from a document (tags-off requests)."""
+    for s in doc.strings.static_strings:
+        s.tags.clear()
+    for s in doc.strings.language_strings:
+        s.tags.clear()
+    for s in doc.strings.language_strings_missed:
+        s.tags.clear()
+    _clear_layout_tags(doc.layout)
+
+
+def _clear_layout_tags(layout: Optional[ResultLayout]) -> None:
+    if layout is None:
+        return
+    for s in layout.strings:
+        s.tags.clear()
+    for child in layout.children:
+        _clear_layout_tags(child)
 
 
 def _acquire_lock(lock_path: Path) -> Optional[int]:

--- a/floss/cache.py
+++ b/floss/cache.py
@@ -24,7 +24,8 @@ document never writes to the cache.
 
 The cache directory defaults to the platform cache directory and can be
 overridden with ``FLOSS_CACHE_DIR``. Caching can be disabled entirely by
-setting ``FLOSS_CACHE_ENABLE=0``.
+setting ``FLOSS_CACHE_ENABLE=0``, and a single run can be forced to
+re-analyze and overwrite its entry with ``FLOSS_CACHE_REFRESH=1``.
 """
 
 from __future__ import annotations
@@ -52,9 +53,12 @@ logger = floss.logging_.getLogger(__name__)
 
 ENV_CACHE_DIR = "FLOSS_CACHE_DIR"
 ENV_CACHE_ENABLE = "FLOSS_CACHE_ENABLE"
+ENV_CACHE_REFRESH = "FLOSS_CACHE_REFRESH"
 
 # values that disable caching, so FLOSS_CACHE_ENABLE=0 behaves as documented
 _DISABLED_VALUES = ("0", "false", "no", "n", "")
+# values that force a re-analysis, so FLOSS_CACHE_REFRESH=1 behaves as documented
+_ENABLED_VALUES = ("1", "true", "yes", "y")
 
 
 def cache_enabled() -> bool:
@@ -64,6 +68,16 @@ def cache_enabled() -> bool:
     caching is enabled by default.
     """
     return os.environ.get(ENV_CACHE_ENABLE, "1") not in _DISABLED_VALUES
+
+
+def cache_refresh() -> bool:
+    """Whether the current run should bypass the cache and overwrite its entry.
+
+    ``FLOSS_CACHE_REFRESH=1`` (or true/yes/y) forces a re-analysis: the cached
+    document is ignored and the fresh result is stored on top of it. Unset by
+    default.
+    """
+    return os.environ.get(ENV_CACHE_REFRESH, "") in _ENABLED_VALUES
 
 
 def get_cache_dir() -> Path:

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -143,6 +143,10 @@ def make_parser():
 
           extract strings from a binary written in Go (if automatic language identification fails)
             floss --language go program.exe
+
+        environment variables:
+          FLOSS_CACHE_DIR      directory for the analysis result cache (default: platform cache directory)
+          FLOSS_CACHE_ENABLE   set to 0 to disable result caching (default: enabled)
         """)
 
     parser = ArgumentParser(

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -147,7 +147,7 @@ def make_parser():
         environment variables:
           FLOSS_CACHE_DIR       directory for the analysis result cache (default: platform cache directory)
           FLOSS_CACHE_ENABLE    set to 0 to disable result caching (default: enabled)
-          FLOSS_CACHE_REFRESH   set to 1 to ignore cached results and overwrite the entry (default: unset)
+          FLOSS_CACHE_REFRESH   set to 1 to ignore cached results and overwrite the entry (default: disabled)
         """)
 
     parser = ArgumentParser(

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -297,7 +297,7 @@ def make_parser():
     )
     advanced_group.add_argument(
         "--analyze-functions",
-        dest="functions",
+        dest="analyze_functions",
         type=lambda x: int(x, 0x10),
         default=None,
         nargs="+",

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -145,8 +145,9 @@ def make_parser():
             floss --language go program.exe
 
         environment variables:
-          FLOSS_CACHE_DIR      directory for the analysis result cache (default: platform cache directory)
-          FLOSS_CACHE_ENABLE   set to 0 to disable result caching (default: enabled)
+          FLOSS_CACHE_DIR       directory for the analysis result cache (default: platform cache directory)
+          FLOSS_CACHE_ENABLE    set to 0 to disable result caching (default: enabled)
+          FLOSS_CACHE_REFRESH   set to 1 to ignore cached results and overwrite the entry (default: unset)
         """)
 
     parser = ArgumentParser(

--- a/floss/main.py
+++ b/floss/main.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import rich.traceback
 
+import floss.cache
 import floss.results
 import floss.logging_
 import floss.render.json
@@ -36,6 +37,7 @@ from floss.utils import FileType, detect_file_type, expand_string_types, is_stri
 from floss.results import Analysis, load
 from floss.pipeline import Options, PipelineError, analyze
 from floss.render.filter import LayoutFilter
+from floss.language.identify import Language
 
 logger = floss.logging_.getLogger("floss")
 
@@ -170,6 +172,18 @@ def main(argv=None) -> int:
 
     set_log_config(args.debug, args.quiet)
 
+    # caching applies to the default analysis variant only: an explicit format,
+    # language, or custom signatures change the analysis, so the content-
+    # addressed cache could return a mismatched document. disable it for those.
+    cache_dir = None
+    if (
+        not args.functions
+        and args.format == "auto"
+        and args.language == Language.AUTO.value
+        and args.signatures == SIGNATURES_PATH_DEFAULT_STRING
+    ):
+        cache_dir = floss.cache.get_cache_dir()
+
     if hasattr(args, "signatures"):
         if args.signatures == SIGNATURES_PATH_DEFAULT_STRING:
             logger.debug("-" * 80)
@@ -267,6 +281,7 @@ def main(argv=None) -> int:
         quiet=args.quiet,
         verbose=args.verbose,
         prompt_deobfuscation=args.prompt_deobfuscation,
+        cache_dir=cache_dir,
     )
 
     try:

--- a/floss/main.py
+++ b/floss/main.py
@@ -177,7 +177,7 @@ def main(argv=None) -> int:
     # addressed cache could return a mismatched document. disable it for those.
     cache_dir = None
     if (
-        not args.functions
+        not args.analyze_functions
         and args.format == "auto"
         and args.language == Language.AUTO.value
         and args.signatures == SIGNATURES_PATH_DEFAULT_STRING
@@ -212,7 +212,7 @@ def main(argv=None) -> int:
         logger.info("--summary is static-only; skipping stack/tight/decoded extraction")
         disabled_string_types.extend([StringType.STACK.value, StringType.TIGHT.value, StringType.DECODED.value])
 
-    if args.functions:
+    if args.analyze_functions:
         static_was_enabled = is_string_type_enabled(StringType.STATIC, disabled_string_types, enabled_string_types)
         try:
             if enabled_string_types and StringType.STATIC.value in enabled_string_types:
@@ -245,7 +245,7 @@ def main(argv=None) -> int:
 
     if detect_file_type(sample) is FileType.RESULTS:
         try:
-            results = load(sample, analysis, args.functions, args.min_length)
+            results = load(sample, analysis, args.analyze_functions, args.min_length)
         except floss.results.InvalidResultsFile as e:
             if args.json:
                 emit_json_error(f"cannot load JSON results file: {e}")
@@ -275,7 +275,7 @@ def main(argv=None) -> int:
         language=args.language,
         enabled_string_types=enabled_string_types,
         disabled_string_types=disabled_string_types,
-        functions=args.functions,
+        analyze_functions=args.analyze_functions,
         signatures=args.signatures,
         large_file=args.large_file,
         quiet=args.quiet,

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -318,9 +318,10 @@ def analyze(options: Options) -> Optional[ResultDocument]:
 
     # result caching: keyed on the sample bytes + FLOSS version. on a valid hit
     # we skip extraction, layout, and tagging entirely and render from the cache.
-    # --analyze-functions changes which functions are analyzed, so it is a miss.
     cache_key: Optional[str] = None
     if options.cache_dir is not None and not options.functions and floss.cache.cache_enabled():
+        # --analyze-functions changes which functions are analyzed, so it is a miss:
+        # a hit would wrongly return a full-function document.
         cache_key = floss.cache.compute_key(results.metadata.sha256, __version__)
         cached = floss.cache.load(options.cache_dir, cache_key, results.metadata.sha256, __version__)
         if cached is not None and floss.cache.covers(cached, analysis, options.min_length):

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -100,7 +100,7 @@ class Options:
     language: str = Language.UNKNOWN.value
     enabled_string_types: Optional[List[str]] = None
     disabled_string_types: Optional[List[str]] = None
-    functions: Optional[List[int]] = None
+    analyze_functions: Optional[List[int]] = None
     signatures: Optional[Path] = None
     large_file: bool = False
     quiet: bool = False
@@ -319,7 +319,7 @@ def analyze(options: Options) -> Optional[ResultDocument]:
     # result caching: keyed on the sample bytes + FLOSS version. on a valid hit
     # we skip extraction, layout, and tagging entirely and render from the cache.
     cache_key: Optional[str] = None
-    if options.cache_dir is not None and not options.functions and floss.cache.cache_enabled():
+    if options.cache_dir is not None and not options.analyze_functions and floss.cache.cache_enabled():
         # --analyze-functions changes which functions are analyzed, so it is a miss:
         # a hit would wrongly return a full-function document.
         cache_key = floss.cache.compute_key(results.metadata.sha256, __version__)
@@ -531,7 +531,7 @@ def analyze(options: Options) -> Optional[ResultDocument]:
 
         with results.metadata.runtime.measure_and_set_time("find_features"):
             try:
-                selected_functions = select_functions(vw, options.functions)
+                selected_functions = select_functions(vw, options.analyze_functions)
                 results.analysis.functions.discovered = len(vw.getFunctions())
             except ValueError as e:
                 # failed to find functions in workspace

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -33,6 +33,7 @@ import viv_utils
 import viv_utils.flirt
 from vivisect import VivWorkspace
 
+import floss.cache
 import floss.utils
 import floss.results
 import floss.logging_
@@ -61,6 +62,7 @@ from floss.layout import Layout
 from floss.render import Verbosity
 from floss.results import Runtime, Analysis, Metadata, ResultLayout, ResultDocument
 from floss.strings import extract_ascii_unicode_strings
+from floss.version import __version__
 from floss.identify import (
     append_unique,
     get_function_fvas,
@@ -106,6 +108,9 @@ class Options:
     verbose: int = Verbosity.DEFAULT
     # when True, prompt on TTY for deobfuscation on language binaries
     prompt_deobfuscation: bool = True
+    # analysis cache directory; None disables caching (default in the CLI is
+    # the platform cache directory via floss.cache.get_cache_dir())
+    cache_dir: Optional[Path] = None
 
 
 def select_functions(vw, asked_functions: Optional[List[int]]) -> Set[int]:
@@ -310,6 +315,17 @@ def analyze(options: Options) -> Optional[ResultDocument]:
     results.metadata.md5 = hashlib.md5(sample_buf).hexdigest()
     results.metadata.sha1 = hashlib.sha1(sample_buf).hexdigest()
     results.metadata.sha256 = hashlib.sha256(sample_buf).hexdigest()
+
+    # result caching: keyed on the sample bytes + FLOSS version. on a valid hit
+    # we skip extraction, layout, and tagging entirely and render from the cache.
+    # --analyze-functions changes which functions are analyzed, so it is a miss.
+    cache_key: Optional[str] = None
+    if options.cache_dir is not None and not options.functions and floss.cache.cache_enabled():
+        cache_key = floss.cache.compute_key(results.metadata.sha256, __version__)
+        cached = floss.cache.load(options.cache_dir, cache_key, results.metadata.sha256, __version__)
+        if cached is not None and floss.cache.covers(cached, analysis, options.min_length):
+            logger.debug("using cached results: %s", cache_key)
+            return floss.cache.materialize(cached, sample, analysis, options.min_length)
 
     static_strings = list(extract_ascii_unicode_strings(sample_buf, options.min_length))
     if not static_strings:
@@ -592,5 +608,9 @@ def analyze(options: Options) -> Optional[ResultDocument]:
 
     results.metadata.runtime.total = get_runtime_diff(time0)
     logger.info("finished execution after %.2f seconds", results.metadata.runtime.total)
+
+    if cache_key is not None and options.cache_dir is not None:
+        logger.debug("storing results in cache: %s", cache_key)
+        floss.cache.store(options.cache_dir, cache_key, results)
 
     return results

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -318,15 +318,19 @@ def analyze(options: Options) -> Optional[ResultDocument]:
 
     # result caching: keyed on the sample bytes + FLOSS version. on a valid hit
     # we skip extraction, layout, and tagging entirely and render from the cache.
+    # FLOSS_CACHE_REFRESH=1 forces a miss so the fresh result overwrites the entry.
     cache_key: Optional[str] = None
     if options.cache_dir is not None and not options.analyze_functions and floss.cache.cache_enabled():
         # --analyze-functions changes which functions are analyzed, so it is a miss:
         # a hit would wrongly return a full-function document.
         cache_key = floss.cache.compute_key(results.metadata.sha256, __version__)
-        cached = floss.cache.load(options.cache_dir, cache_key, results.metadata.sha256, __version__)
-        if cached is not None and floss.cache.covers(cached, analysis, options.min_length):
-            logger.debug("using cached results: %s", cache_key)
-            return floss.cache.materialize(cached, sample, analysis, options.min_length)
+        if not floss.cache.cache_refresh():
+            cached = floss.cache.load(options.cache_dir, cache_key, results.metadata.sha256, __version__)
+            if cached is not None and floss.cache.covers(cached, analysis, options.min_length):
+                logger.debug("using cached results: %s", cache_key)
+                return floss.cache.materialize(cached, sample, analysis, options.min_length)
+        else:
+            logger.debug("FLOSS_CACHE_REFRESH set; re-analyzing and overwriting cache entry %s", cache_key)
 
     static_strings = list(extract_ascii_unicode_strings(sample_buf, options.min_length))
     if not static_strings:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import yaml
 import pytest
 import viv_utils
 
+import floss.cache
 from floss.const import MIN_STRING_LENGTH
 from floss.identify import (
     get_function_fvas,
@@ -29,6 +30,14 @@ from floss.identify import (
     get_functions_without_tightloops,
 )
 from floss.pipeline import select_functions
+
+
+@pytest.fixture(autouse=True)
+def _isolate_analysis_cache(tmp_path, monkeypatch):
+    """point the analysis cache at a throwaway directory per test so tests never
+    touch the real platform cache, and make caching deterministic."""
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(tmp_path / "floss-cache"))
+    monkeypatch.setenv(floss.cache.ENV_CACHE_ENABLE, "1")
 
 
 def extract_strings(vw):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -194,9 +194,10 @@ def test_covers_layout_enabled_mismatch_is_miss():
     assert not floss.cache.covers(doc, wanted(enable_layout=True), 4)
 
 
-def test_covers_layout_disabled_mismatch_is_miss():
+def test_covers_layout_disabled_is_hit():
+    # a cached layout can satisfy a no-layout request: materialize() drops it
     doc = make_doc(enable_layout=True)
-    assert not floss.cache.covers(doc, wanted(enable_layout=False), 4)
+    assert floss.cache.covers(doc, wanted(enable_layout=False), 4)
 
 
 def test_covers_tags_enabled_mismatch_is_miss():
@@ -221,3 +222,15 @@ def test_materialize_sets_file_path_and_filters(tmp_path):
     assert mat.metadata.file_path == str(sample)
     # "hello" is 5 chars, below the requested -n 8
     assert mat.strings.static_strings == []
+
+
+def test_materialize_drops_layout_when_disabled(tmp_path):
+    doc = make_doc(enable_layout=True)
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+    floss.cache.store(tmp_path, key, doc)
+    loaded = floss.cache.load(tmp_path, key, doc.metadata.sha256, __version__)
+    assert loaded is not None
+    assert loaded.layout is not None
+
+    mat = floss.cache.materialize(loaded, tmp_path / "sample.exe", wanted(enable_layout=False), 4)
+    assert mat.layout is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,8 +8,13 @@ from floss.results import (
     Strings,
     Analysis,
     Metadata,
+    AddressType,
+    StackString,
+    TightString,
     ResultLayout,
+    ResultString,
     StaticString,
+    DecodedString,
     ResultDocument,
     StringEncoding,
 )
@@ -49,6 +54,67 @@ def make_doc(
         ),
         strings=Strings(
             static_strings=[StaticString(string="hello", offset=0, encoding=StringEncoding.ASCII)],
+        ),
+        layout=layout,
+    )
+
+
+def make_full_doc():
+    layout = ResultLayout(
+        name="pe",
+        offset=0,
+        length=8,
+        strings=[ResultString(string="layout", offset=0, size=6, encoding="ASCII", tags=["#winapi"])],
+    )
+    return ResultDocument(
+        metadata=Metadata(file_path="sample.exe", sha256="a" * 64, version=__version__, min_length=4),
+        analysis=Analysis(
+            enable_static_strings=True,
+            enable_stack_strings=True,
+            enable_tight_strings=True,
+            enable_decoded_strings=True,
+            enable_language_strings=True,
+            enable_layout=True,
+            enable_tags=True,
+        ),
+        strings=Strings(
+            static_strings=[StaticString(string="hello", offset=0, encoding=StringEncoding.ASCII, tags=["#common"])],
+            stack_strings=[
+                StackString(
+                    function=0,
+                    string="stack",
+                    encoding=StringEncoding.ASCII,
+                    program_counter=0,
+                    stack_pointer=0,
+                    original_stack_pointer=0,
+                    offset=0,
+                    frame_offset=0,
+                )
+            ],
+            tight_strings=[
+                TightString(
+                    function=0,
+                    string="tight",
+                    encoding=StringEncoding.ASCII,
+                    program_counter=0,
+                    stack_pointer=0,
+                    original_stack_pointer=0,
+                    offset=0,
+                    frame_offset=0,
+                )
+            ],
+            decoded_strings=[
+                DecodedString(
+                    address=0,
+                    address_type=AddressType.STACK,
+                    string="decoded",
+                    encoding=StringEncoding.ASCII,
+                    decoded_at=0,
+                    decoding_routine=0,
+                )
+            ],
+            language_strings=[StaticString(string="go", offset=0, encoding=StringEncoding.UTF8, tags=["#go"])],
+            language_strings_missed=[StaticString(string="missed", offset=0, encoding=StringEncoding.UTF8)],
         ),
         layout=layout,
     )
@@ -234,3 +300,43 @@ def test_materialize_drops_layout_when_disabled(tmp_path):
 
     mat = floss.cache.materialize(loaded, tmp_path / "sample.exe", wanted(enable_layout=False), 4)
     assert mat.layout is None
+
+
+def test_materialize_clears_disabled_string_types():
+    mat = floss.cache.materialize(make_full_doc(), Path("sample.exe"), wanted(), 4)
+    assert mat.analysis.enable_static_strings is True
+    assert mat.strings.static_strings
+
+    disabled = Analysis(
+        enable_static_strings=False,
+        enable_stack_strings=False,
+        enable_tight_strings=False,
+        enable_decoded_strings=False,
+        enable_language_strings=False,
+    )
+    mat = floss.cache.materialize(make_full_doc(), Path("sample.exe"), disabled, 4)
+    assert mat.strings.static_strings == []
+    assert mat.strings.stack_strings == []
+    assert mat.strings.tight_strings == []
+    assert mat.strings.decoded_strings == []
+    assert mat.strings.language_strings == []
+    assert mat.strings.language_strings_missed == []
+    # static strings are disabled, so the layout that holds them is gone too
+    assert mat.layout is None
+
+
+def test_materialize_clears_only_disabled_types():
+    disabled_stack = Analysis(enable_stack_strings=False)
+    mat = floss.cache.materialize(make_full_doc(), Path("sample.exe"), disabled_stack, 4)
+    assert mat.strings.stack_strings == []
+    assert mat.strings.static_strings
+    assert mat.strings.tight_strings
+    assert mat.strings.decoded_strings
+    assert mat.layout is not None
+
+
+def test_materialize_syncs_layout_and_tag_flags():
+    doc = make_full_doc()
+    mat = floss.cache.materialize(doc, Path("sample.exe"), Analysis(enable_layout=False, enable_tags=False), 4)
+    assert mat.analysis.enable_layout is False
+    assert mat.analysis.enable_tags is False

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -90,8 +91,10 @@ def test_get_cache_dir_override(monkeypatch, tmp_path):
 
 
 def test_get_cache_dir_default(monkeypatch):
+    from platformdirs import user_cache_dir
+
     monkeypatch.delenv(floss.cache.ENV_CACHE_DIR, raising=False)
-    assert str(floss.cache.get_cache_dir()).endswith("floss")
+    assert floss.cache.get_cache_dir() == Path(user_cache_dir("floss"))
 
 
 def test_compute_key():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,6 @@
 import os
 import json
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -264,6 +265,30 @@ def test_store_skips_when_replace_fails(tmp_path, monkeypatch):
     assert not (tmp_path / f"{key}.json").exists()
     # the temporary file is cleaned up
     assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_store_skips_when_mkdir_fails(tmp_path, monkeypatch):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+    cache_dir = tmp_path / "cache"
+
+    def raising_mkdir(self, *args, **kwargs):
+        raise PermissionError("no write access to cache directory")
+
+    monkeypatch.setattr(Path, "mkdir", raising_mkdir)
+    assert floss.cache.store(cache_dir, key, doc) is False
+
+
+def test_store_skips_when_mkstemp_fails(tmp_path, monkeypatch):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+
+    def raising_mkstemp(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(tempfile, "mkstemp", raising_mkstemp)
+    assert floss.cache.store(tmp_path, key, doc) is False
+    assert not (tmp_path / f"{key}.json").exists()
 
 
 def test_load_drops_version_mismatch(tmp_path):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -417,6 +417,13 @@ def test_materialize_syncs_layout_and_tag_flags():
     assert mat.analysis.enable_tags is False
 
 
+def test_materialize_updates_metadata_min_length():
+    # a -n 6 hit against a -n 4 cache entry must report the requested length
+    mat = floss.cache.materialize(make_full_doc(), Path("sample.exe"), wanted(), 6)
+    assert mat.metadata.min_length == 6
+    assert all(len(s.string) >= 6 for s in mat.strings.static_strings)
+
+
 def test_materialize_clears_tags_when_disabled():
     doc = make_full_doc()
     assert doc.strings.static_strings[0].tags == ["#common"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -152,6 +152,17 @@ def test_cache_enabled_disabled(monkeypatch, value):
     assert not floss.cache.cache_enabled()
 
 
+def test_cache_refresh_default(monkeypatch):
+    monkeypatch.delenv(floss.cache.ENV_CACHE_REFRESH, raising=False)
+    assert not floss.cache.cache_refresh()
+
+
+@pytest.mark.parametrize("value", ("1", "true", "yes", "y"))
+def test_cache_refresh_enabled(monkeypatch, value):
+    monkeypatch.setenv(floss.cache.ENV_CACHE_REFRESH, value)
+    assert floss.cache.cache_refresh()
+
+
 def test_get_cache_dir_override(monkeypatch, tmp_path):
     monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(tmp_path))
     assert floss.cache.get_cache_dir() == tmp_path

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -388,6 +388,7 @@ def test_materialize_clears_tags_when_disabled():
 
     # Analysis(enable_tags=False) keeps every string type enabled, tags off
     mat = floss.cache.materialize(doc, Path("sample.exe"), Analysis(enable_tags=False), 4)
+    assert mat.layout is not None
     assert mat.strings.static_strings[0].tags == []
     assert mat.strings.language_strings[0].tags == []
     assert mat.layout.strings[0].tags == []
@@ -395,5 +396,6 @@ def test_materialize_clears_tags_when_disabled():
 
 def test_materialize_keeps_tags_when_enabled():
     mat = floss.cache.materialize(make_full_doc(), Path("sample.exe"), wanted(), 4)
+    assert mat.layout is not None
     assert mat.strings.static_strings[0].tags == ["#common"]
     assert mat.layout.strings[0].tags == ["#winapi"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -303,6 +303,17 @@ def test_store_skips_when_mkstemp_fails(tmp_path, monkeypatch):
     assert not (tmp_path / f"{key}.json").exists()
 
 
+def test_load_skips_when_isfile_fails(tmp_path, monkeypatch):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+
+    def raising_is_file(self, *args, **kwargs):
+        raise PermissionError("no read access to cache directory")
+
+    monkeypatch.setattr(Path, "is_file", raising_is_file)
+    assert floss.cache.load(tmp_path, key, doc.metadata.sha256, __version__) is None
+
+
 def test_load_drops_version_mismatch(tmp_path):
     doc = make_doc(version="9.9.9")
     key = floss.cache.compute_key(doc.metadata.sha256, __version__)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,220 @@
+import json
+
+import pytest
+
+import floss.cache
+from floss.results import (
+    Strings,
+    Analysis,
+    Metadata,
+    ResultLayout,
+    StaticString,
+    ResultDocument,
+    StringEncoding,
+)
+from floss.version import __version__
+
+
+def make_doc(
+    sha256="a" * 64,
+    version=__version__,
+    min_length=4,
+    enable_static=True,
+    enable_stack=False,
+    enable_tight=False,
+    enable_decoded=False,
+    enable_language=False,
+    enable_layout=True,
+    enable_tags=True,
+):
+    layout = ResultLayout(name="pe", offset=0, length=8) if enable_layout else None
+    return ResultDocument(
+        metadata=Metadata(
+            file_path="sample.exe",
+            md5="0" * 32,
+            sha1="0" * 40,
+            sha256=sha256,
+            version=version,
+            min_length=min_length,
+        ),
+        analysis=Analysis(
+            enable_static_strings=enable_static,
+            enable_stack_strings=enable_stack,
+            enable_tight_strings=enable_tight,
+            enable_decoded_strings=enable_decoded,
+            enable_language_strings=enable_language,
+            enable_layout=enable_layout,
+            enable_tags=enable_tags,
+        ),
+        strings=Strings(
+            static_strings=[StaticString(string="hello", offset=0, encoding=StringEncoding.ASCII)],
+        ),
+        layout=layout,
+    )
+
+
+def wanted(
+    enable_static=True,
+    enable_stack=False,
+    enable_tight=False,
+    enable_decoded=False,
+    enable_language=False,
+    enable_layout=True,
+    enable_tags=True,
+):
+    return Analysis(
+        enable_static_strings=enable_static,
+        enable_stack_strings=enable_stack,
+        enable_tight_strings=enable_tight,
+        enable_decoded_strings=enable_decoded,
+        enable_language_strings=enable_language,
+        enable_layout=enable_layout,
+        enable_tags=enable_tags,
+    )
+
+
+def test_cache_enabled_default(monkeypatch):
+    monkeypatch.delenv(floss.cache.ENV_CACHE_ENABLE, raising=False)
+    assert floss.cache.cache_enabled()
+
+
+@pytest.mark.parametrize("value", ("0", "false", "no", "n", ""))
+def test_cache_enabled_disabled(monkeypatch, value):
+    monkeypatch.setenv(floss.cache.ENV_CACHE_ENABLE, value)
+    assert not floss.cache.cache_enabled()
+
+
+def test_get_cache_dir_override(monkeypatch, tmp_path):
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(tmp_path))
+    assert floss.cache.get_cache_dir() == tmp_path
+
+
+def test_get_cache_dir_default(monkeypatch):
+    monkeypatch.delenv(floss.cache.ENV_CACHE_DIR, raising=False)
+    assert str(floss.cache.get_cache_dir()).endswith("floss")
+
+
+def test_compute_key():
+    sha256 = "a" * 64
+    assert floss.cache.compute_key(sha256, "1.0") == f"{sha256}-1.0"
+
+
+def test_cache_file_path(tmp_path):
+    assert floss.cache.cache_file_path(tmp_path, "key") == tmp_path / "key.json"
+
+
+def test_store_and_load_roundtrip(tmp_path):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+
+    assert floss.cache.store(tmp_path, key, doc)
+    assert (tmp_path / f"{key}.json").is_file()
+
+    loaded = floss.cache.load(tmp_path, key, doc.metadata.sha256, __version__)
+    assert loaded is not None
+    assert loaded.metadata.sha256 == doc.metadata.sha256
+    assert loaded.metadata.version == __version__
+    assert loaded.strings.static_strings[0].string == "hello"
+
+
+def test_store_writes_json_schema(tmp_path):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+
+    floss.cache.store(tmp_path, key, doc)
+    payload = json.loads((tmp_path / f"{key}.json").read_text())
+    assert set(("metadata", "analysis", "strings")) <= set(payload.keys())
+
+
+def test_load_missing(tmp_path):
+    key = floss.cache.compute_key("a" * 64, __version__)
+    assert floss.cache.load(tmp_path, key, "a" * 64, __version__) is None
+
+
+def test_load_drops_invalid_json(tmp_path):
+    key = floss.cache.compute_key("a" * 64, __version__)
+    (tmp_path / f"{key}.json").write_text("{not json")
+
+    assert floss.cache.load(tmp_path, key, "a" * 64, __version__) is None
+    assert not (tmp_path / f"{key}.json").exists()
+
+
+def test_load_drops_checksum_mismatch(tmp_path):
+    doc = make_doc(sha256="a" * 64)
+    key = floss.cache.compute_key("a" * 64, __version__)
+    floss.cache.store(tmp_path, key, doc)
+
+    assert floss.cache.load(tmp_path, key, "b" * 64, __version__) is None
+    assert not (tmp_path / f"{key}.json").exists()
+
+
+def test_load_drops_version_mismatch(tmp_path):
+    doc = make_doc(version="9.9.9")
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+    floss.cache.store(tmp_path, key, doc)
+
+    assert floss.cache.load(tmp_path, key, doc.metadata.sha256, __version__) is None
+    assert not (tmp_path / f"{key}.json").exists()
+
+
+def test_store_skips_when_locked(tmp_path):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+    lock_path = tmp_path / f"{key}.lock"
+
+    fd = floss.cache._acquire_lock(lock_path)
+    assert fd is not None
+    try:
+        assert floss.cache.store(tmp_path, key, doc) is False
+        assert not (tmp_path / f"{key}.json").exists()
+    finally:
+        floss.cache._release_lock(fd, lock_path)
+
+
+def test_covers_matches():
+    doc = make_doc()
+    assert floss.cache.covers(doc, wanted(), 4)
+
+
+def test_covers_missing_requested_type_is_miss():
+    doc = make_doc(enable_static=True, enable_stack=False)
+    assert not floss.cache.covers(doc, wanted(enable_stack=True), 4)
+
+
+def test_covers_min_length_below_stored_is_miss():
+    doc = make_doc(min_length=8)
+    assert not floss.cache.covers(doc, wanted(), 4)
+
+
+def test_covers_layout_enabled_mismatch_is_miss():
+    doc = make_doc(enable_layout=False)
+    assert not floss.cache.covers(doc, wanted(enable_layout=True), 4)
+
+
+def test_covers_layout_disabled_mismatch_is_miss():
+    doc = make_doc(enable_layout=True)
+    assert not floss.cache.covers(doc, wanted(enable_layout=False), 4)
+
+
+def test_covers_tags_enabled_mismatch_is_miss():
+    doc = make_doc(enable_tags=False)
+    assert not floss.cache.covers(doc, wanted(enable_tags=True), 4)
+
+
+def test_covers_tags_disabled_mismatch_is_miss():
+    doc = make_doc(enable_tags=True)
+    assert not floss.cache.covers(doc, wanted(enable_tags=False), 4)
+
+
+def test_materialize_sets_file_path_and_filters(tmp_path):
+    doc = make_doc(min_length=4)
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+    floss.cache.store(tmp_path, key, doc)
+    loaded = floss.cache.load(tmp_path, key, doc.metadata.sha256, __version__)
+    assert loaded is not None
+
+    sample = tmp_path / "run" / "sample.exe"
+    mat = floss.cache.materialize(loaded, sample, wanted(), 8)
+    assert mat.metadata.file_path == str(sample)
+    # "hello" is 5 chars, below the requested -n 8
+    assert mat.strings.static_strings == []

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -114,7 +114,7 @@ def make_full_doc():
                     decoding_routine=0,
                 )
             ],
-            language_strings=[StaticString(string="go", offset=0, encoding=StringEncoding.UTF8, tags=["#go"])],
+            language_strings=[StaticString(string="gostring", offset=0, encoding=StringEncoding.UTF8, tags=["#go"])],
             language_strings_missed=[StaticString(string="missed", offset=0, encoding=StringEncoding.UTF8)],
         ),
         layout=layout,
@@ -309,9 +309,10 @@ def test_covers_tags_enabled_mismatch_is_miss():
     assert not floss.cache.covers(doc, wanted(enable_tags=True), 4)
 
 
-def test_covers_tags_disabled_mismatch_is_miss():
+def test_covers_tags_disabled_is_hit():
+    # a tags-enabled document satisfies a no-tags request: materialize redacts
     doc = make_doc(enable_tags=True)
-    assert not floss.cache.covers(doc, wanted(enable_tags=False), 4)
+    assert floss.cache.covers(doc, wanted(enable_tags=False), 4)
 
 
 def test_materialize_sets_file_path_and_filters(tmp_path):
@@ -378,3 +379,21 @@ def test_materialize_syncs_layout_and_tag_flags():
     mat = floss.cache.materialize(doc, Path("sample.exe"), Analysis(enable_layout=False, enable_tags=False), 4)
     assert mat.analysis.enable_layout is False
     assert mat.analysis.enable_tags is False
+
+
+def test_materialize_clears_tags_when_disabled():
+    doc = make_full_doc()
+    assert doc.strings.static_strings[0].tags == ["#common"]
+    assert doc.layout.strings[0].tags == ["#winapi"]
+
+    # Analysis(enable_tags=False) keeps every string type enabled, tags off
+    mat = floss.cache.materialize(doc, Path("sample.exe"), Analysis(enable_tags=False), 4)
+    assert mat.strings.static_strings[0].tags == []
+    assert mat.strings.language_strings[0].tags == []
+    assert mat.layout.strings[0].tags == []
+
+
+def test_materialize_keeps_tags_when_enabled():
+    mat = floss.cache.materialize(make_full_doc(), Path("sample.exe"), wanted(), 4)
+    assert mat.strings.static_strings[0].tags == ["#common"]
+    assert mat.layout.strings[0].tags == ["#winapi"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -153,6 +153,12 @@ def test_cache_enabled_disabled(monkeypatch, value):
     assert not floss.cache.cache_enabled()
 
 
+@pytest.mark.parametrize("value", ("False", "NO", "N", "FALSE"))
+def test_cache_enabled_disabled_case_insensitive(monkeypatch, value):
+    monkeypatch.setenv(floss.cache.ENV_CACHE_ENABLE, value)
+    assert not floss.cache.cache_enabled()
+
+
 def test_cache_refresh_default(monkeypatch):
     monkeypatch.delenv(floss.cache.ENV_CACHE_REFRESH, raising=False)
     assert not floss.cache.cache_refresh()
@@ -160,6 +166,12 @@ def test_cache_refresh_default(monkeypatch):
 
 @pytest.mark.parametrize("value", ("1", "true", "yes", "y"))
 def test_cache_refresh_enabled(monkeypatch, value):
+    monkeypatch.setenv(floss.cache.ENV_CACHE_REFRESH, value)
+    assert floss.cache.cache_refresh()
+
+
+@pytest.mark.parametrize("value", ("True", "YES", "Y", "TRUE"))
+def test_cache_refresh_enabled_case_insensitive(monkeypatch, value):
     monkeypatch.setenv(floss.cache.ENV_CACHE_REFRESH, value)
     assert floss.cache.cache_refresh()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+import os
 import json
 from pathlib import Path
 
@@ -215,6 +216,43 @@ def test_load_drops_checksum_mismatch(tmp_path):
 
     assert floss.cache.load(tmp_path, key, "b" * 64, __version__) is None
     assert not (tmp_path / f"{key}.json").exists()
+
+
+def test_load_ignores_unlink_failure_on_invalid_entry(tmp_path, monkeypatch):
+    key = floss.cache.compute_key("a" * 64, __version__)
+    (tmp_path / f"{key}.json").write_text("{not json")
+
+    def raising_unlink(self, *args, **kwargs):
+        raise PermissionError("held open by another process")
+
+    monkeypatch.setattr(Path, "unlink", raising_unlink)
+    assert floss.cache.load(tmp_path, key, "a" * 64, __version__) is None
+
+
+def test_load_ignores_unlink_failure_on_stale_entry(tmp_path, monkeypatch):
+    doc = make_doc(sha256="a" * 64)
+    key = floss.cache.compute_key("a" * 64, __version__)
+    floss.cache.store(tmp_path, key, doc)
+
+    def raising_unlink(self, *args, **kwargs):
+        raise PermissionError("held open by another process")
+
+    monkeypatch.setattr(Path, "unlink", raising_unlink)
+    assert floss.cache.load(tmp_path, key, "b" * 64, __version__) is None
+
+
+def test_store_skips_when_replace_fails(tmp_path, monkeypatch):
+    doc = make_doc()
+    key = floss.cache.compute_key(doc.metadata.sha256, __version__)
+
+    def raising_replace(src, dst):
+        raise PermissionError("destination held open by antivirus")
+
+    monkeypatch.setattr(os, "replace", raising_replace)
+    assert floss.cache.store(tmp_path, key, doc) is False
+    assert not (tmp_path / f"{key}.json").exists()
+    # the temporary file is cleaned up
+    assert list(tmp_path.glob("*.tmp")) == []
 
 
 def test_load_drops_version_mismatch(tmp_path):

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -1,0 +1,68 @@
+import hashlib
+import logging
+from pathlib import Path
+
+from fixtures import scfile, exefile
+
+import floss.main
+import floss.cache
+import floss.render.json
+from floss.results import Strings, Analysis, Metadata, ResultDocument
+from floss.version import __version__
+
+
+def cache_entries(cache_dir):
+    return list(cache_dir.rglob("*.json"))
+
+
+def test_cache_hit_skips_analysis_and_matches_output(capsys, caplog, tmp_path, monkeypatch, exefile):
+    caplog.set_level(logging.DEBUG)
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(cache_dir))
+
+    assert floss.main.main([exefile, "--summary"]) == 0
+    out1 = capsys.readouterr().out
+
+    sha256 = hashlib.sha256(Path(exefile).read_bytes()).hexdigest()
+    key = floss.cache.compute_key(sha256, __version__)
+    assert (cache_dir / f"{key}.json").is_file()
+    assert len(cache_entries(cache_dir)) == 1
+
+    caplog.clear()
+    assert floss.main.main([exefile, "--summary", "-d"]) == 0
+    assert any("using cached results" in r.getMessage() for r in caplog.records)
+    assert capsys.readouterr().out == out1
+
+
+def test_cache_disabled_writes_nothing(capsys, tmp_path, monkeypatch, exefile):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(cache_dir))
+    monkeypatch.setenv(floss.cache.ENV_CACHE_ENABLE, "0")
+
+    assert floss.main.main([exefile, "--summary"]) == 0
+    assert cache_entries(cache_dir) == []
+
+
+def test_cache_not_written_for_results_document(capsys, tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(cache_dir))
+
+    doc = ResultDocument(
+        metadata=Metadata(file_path="sample.exe", min_length=4),
+        analysis=Analysis(enable_static_strings=False),
+        strings=Strings(),
+    )
+    results_path = tmp_path / "results.json"
+    results_path.write_text(floss.render.json.render(doc))
+
+    assert floss.main.main([str(results_path)]) == 0
+    assert cache_entries(cache_dir) == []
+
+
+def test_analysis_variant_disables_cache(capsys, tmp_path, monkeypatch, scfile):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(cache_dir))
+
+    # an explicit --format is a non-default analysis variant, so no caching
+    assert floss.main.main([scfile, "-f", "sc32", "--summary"]) == 0
+    assert cache_entries(cache_dir) == []

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -59,6 +59,25 @@ def test_cache_not_written_for_results_document(capsys, tmp_path, monkeypatch):
     assert cache_entries(cache_dir) == []
 
 
+def test_cache_refresh_reanalyzes_and_overwrites(capsys, caplog, tmp_path, monkeypatch, exefile):
+    caplog.set_level(logging.DEBUG)
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(cache_dir))
+
+    assert floss.main.main([exefile, "--summary"]) == 0
+    sha256 = hashlib.sha256(Path(exefile).read_bytes()).hexdigest()
+    key = floss.cache.compute_key(sha256, __version__)
+    assert (cache_dir / f"{key}.json").is_file()
+
+    # FLOSS_CACHE_REFRESH=1 forces a miss, re-analyzes, and overwrites the entry
+    caplog.clear()
+    monkeypatch.setenv(floss.cache.ENV_CACHE_REFRESH, "1")
+    assert floss.main.main([exefile, "--summary", "-d"]) == 0
+    assert not any("using cached results" in r.getMessage() for r in caplog.records)
+    assert any("FLOSS_CACHE_REFRESH" in r.getMessage() for r in caplog.records)
+    assert (cache_dir / f"{key}.json").is_file()
+
+
 def test_analysis_variant_disables_cache(capsys, tmp_path, monkeypatch, scfile):
     cache_dir = tmp_path / "cache"
     monkeypatch.setenv(floss.cache.ENV_CACHE_DIR, str(cache_dir))


### PR DESCRIPTION
## Summary

Implemented §3.5 caching.

## Key decisions

- Cache files use the format `{sha256}-{version}.json`.
- `covers()` checks that a cached result matches the requested analysis settings. If it does not, the cache is ignored and the analysis runs normally.
- Caching is disabled for non-default analysis variants to avoid returning a mismatched document.
- Cache writes use locks and are atomic. If the lock cannot be acquired, the write is skipped with a warning.
- `FLOSS_CACHE_DIR` is supported. Without it, the cache uses `platformdirs.user_cache_dir("floss")`.
- Invalid, corrupted, checksum-mismatched, or version-mismatched cache entries are ignored.

