### PR TITLE
ci: fix OSS DB build by putting repo root on PYTHONPATH

### DIFF
--- a/.github/workflows/build-oss-db.yml
+++ b/.github/workflows/build-oss-db.yml
@@ -51,9 +51,12 @@ jobs:
           cargo build --release -p lancelot-bin
         working-directory: lancelot
 
+      - name: Install flare-floss
+        run: |
+          pip install -e .
+        working-directory: flare-floss
+
       - name: Build OSS databases
-        env:
-          PYTHONPATH: ${{ github.workspace }}/flare-floss
         run: |
           python scripts/tags/build_oss_db.py `
             --config floss\tags\data\oss\libraries.json `

--- a/.github/workflows/build-oss-db.yml
+++ b/.github/workflows/build-oss-db.yml
@@ -52,6 +52,8 @@ jobs:
         working-directory: lancelot
 
       - name: Build OSS databases
+        env:
+          PYTHONPATH: ${{ github.workspace }}/flare-floss
         run: |
           python scripts/tags/build_oss_db.py `
             --config floss\tags\data\oss\libraries.json `
@@ -63,7 +65,11 @@ jobs:
       - name: Show metrics summary
         if: success() || failure()
         run: |
-          Get-Content floss\tags\data\oss\build_metrics.json
+          if (Test-Path floss\tags\data\oss\build_metrics.json) {
+            Get-Content floss\tags\data\oss\build_metrics.json
+          } else {
+            Write-Host "build_metrics.json not produced"
+          }
         working-directory: flare-floss
 
       - name: Show entry-level diff


### PR DESCRIPTION
## What

The `Build OSS String Databases` workflow failed on every run with:

```
ModuleNotFoundError: No module named 'floss'
  File ".../scripts/tags/build_oss_db.py", line 52, in <module>
    from floss.tags import data_root
```

`build_oss_db.py` imports `from floss.tags import data_root`, but the workflow ran it as `python scripts/tags/build_oss_db.py` without `floss` installed — Python only adds the script's directory (`scripts/tags/`) to `sys.path`, so `floss` is not importable. This crashes before anything is built, and the downstream "Show metrics summary" step then errors on the missing `build_metrics.json`.

## Changes

- Add an "Install flare-floss" step (`pip install -e .`) so `floss.tags.data_root` is importable from the script.
- Guard "Show metrics summary" with `Test-Path` (same as "Show entry-level diff") so it doesn't hard-fail when the build produces no metrics.

## Verification

- `tests/test_build_oss_db.py` + `tests/test_oss_db.py`: 49 passed
- pre-commit (isort, black, mypy): passed
- Confirmed the script imports and parses args with `floss` installed, without `PYTHONPATH`, from both the repo root and a neutral cwd
- Confirmed vcpkg is preinstalled/on PATH on the `windows-latest` runner image (script's `shutil.which("vcpkg")` resolves it)