### PR TITLE
fix(viewer): use relative asset paths so the logo loads on GitHub Pages

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FLOSS Graphical Viewer</title>
-  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="icon" type="image/png" href="favicon.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -620,7 +620,7 @@ const App: React.FC = () => {
       {/* ---- Sidebar ---- */}
       <div className="sidebar" style={{ width: sidebarWidth }}>
         <div className="sidebar-header">
-          <img className="app-logo" src="/floss-logo.png" alt="FLOSS" />
+          <img className="app-logo" src="floss-logo.png" alt="FLOSS" />
           <div className="sidebar-header-buttons">
             <button
               className="btn-ghost"


### PR DESCRIPTION
## Fix

The web viewer at https://mandiant.github.io/flare-floss/ requests the logo from the org root instead of the project subpath, so it 404s and the sidebar header shows a broken image.

The viewer used absolute asset paths:

- `/floss-logo.png` in `viewer/src/App.tsx`
- `/favicon.png` in `viewer/index.html`

GitHub Pages serves project sites from a subpath (`mandiant.github.io/flare-floss/`). Browsers resolve absolute paths against the domain root, so these became `https://mandiant.github.io/floss-logo.png`, which does not exist. The network panel in issue #1396 shows exactly this: `GET https://mandiant.github.io/floss-logo.png -> 404`.

This changes both references to relative paths (`floss-logo.png`, `favicon.png`). Relative URLs resolve against the page URL, so they work under the `/flare-floss/` subpath and in local dev.

Fixes #1396