### PR TITLE
ci: skip PyInstaller build for doc-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: build
 on:
   pull_request:
     branches: [ master, quantumstrand ]
+    # PyInstaller builds and their smoke tests can't be affected by these files
+    paths-ignore:
+      - 'viewer/**'
+      - 'doc/**'
+      - '**.md'
   release:
     types: [edited, published]
     branches: [ master ]


### PR DESCRIPTION
Adds paths-ignore to build.yml so doc-only and viewer-only PRs stop running the PyInstaller build and its smoke tests, which can't be affected by those files. tests.yml already skips these paths (merged in #1399).