### PR TITLE
Add shell completion scripts (--print-completion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Display the help/usage screens:
 
     $ floss -h  # show all supported arguments
 
+Enable tab completion for flags, choice values, and file paths with `floss --print-completion bash`
+(also zsh, fish); installation instructions are in [doc/usage.md](doc/usage.md#shell-completions).
+
 For a detailed description of using FLOSS, review the documentation
  [here](doc/usage.md).
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -275,6 +275,35 @@ After this option is installed, you can right-click on any file and select `Open
  to quickly open the target file with FLOSS for analysis.
 
 
+### Shell completions (`--print-completion {bash,zsh,tcsh,fish,powershell}`)
+
+FLOSS can print a tab-completion script for your shell. The script is generated
+from FLOSS's argument definitions, so flags, choice values (such as
+`--string-type static`), and sample file paths all complete as you type.
+
+    floss --print-completion bash
+
+Install the output for your shell:
+
+bash:
+
+    mkdir -p ~/.local/share/bash_completion
+    floss --print-completion bash > ~/.local/share/bash_completion/floss
+    echo 'source ~/.local/share/bash_completion/floss' >> ~/.bashrc
+
+zsh (requires `compinit`, which most frameworks and default configs run):
+
+    mkdir -p ~/.local/share/zsh/site-functions
+    floss --print-completion zsh > ~/.local/share/zsh/site-functions/_floss
+
+fish:
+
+    mkdir -p ~/.config/fish/completions
+    floss --print-completion fish > ~/.config/fish/completions/floss.fish
+
+Then restart your shell or start a new one.
+
+
 ## <a name="shellcode"></a>Shellcode analysis options
 
 Malicious shellcode often times contains obfuscated strings or stackstrings.

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -24,6 +24,8 @@ from enum import Enum
 from typing import List, Optional
 from pathlib import Path
 
+import shtab
+
 import floss.utils
 import floss.logging_
 from floss.const import (
@@ -151,6 +153,7 @@ def make_parser():
         """)
 
     parser = ArgumentParser(
+        prog="floss",
         description=desc,
         epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -164,11 +167,13 @@ def make_parser():
         help="minimum string length",
     )
 
-    parser.add_argument(
+    sample_argument = parser.add_argument(
         "sample",
         type=argparse.FileType("rb"),
         help="path to sample to analyze",
     )
+    # enable file path completion for the sample positional argument
+    setattr(sample_argument, "complete", shtab.FILE)
 
     analysis_group = parser.add_argument_group("analysis arguments")
     analysis_group.add_argument(
@@ -334,6 +339,12 @@ def make_parser():
             action=floss.utils.UninstallContextMenu,
             help="uninstall FLOSS from the right-click context menu for Windows Explorer and exit",
         )
+
+    shtab.add_argument_to(
+        parser,
+        ["--print-completion"],
+        help="print shell completion script for the given shell",
+    )
 
     output_group = parser.add_argument_group("rendering arguments")
     output_group.add_argument("-j", "--json", action="store_true", help="emit JSON instead of text")

--- a/floss/cli.py
+++ b/floss/cli.py
@@ -343,7 +343,7 @@ def make_parser():
     shtab.add_argument_to(
         parser,
         ["--print-completion"],
-        help="print shell completion script for the given shell",
+        help="print shell completion script for bash, zsh, tcsh, fish, or powershell",
     )
 
     output_group = parser.add_argument_group("rendering arguments")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dependencies = [
     "tqdm>=4",
     "halo>=0.0.31",
     "rich>=13",
+    "shtab>=1.7",
     "pefile>=2022.5.30",
     "binary2strings>=0.1",
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ python-lancelot==0.10.0
 pyyaml==6.0.1
 rich==15.0.0
 setuptools==84.0.0
+shtab==1.12.0
 six==1.17.0
 sortedcontainers==2.4.0
 spinners==0.0.24

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+import floss.main
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+def test_print_completion(shell, capsys):
+    """--print-completion emits a non-empty completion script and exits cleanly."""
+    with pytest.raises(SystemExit) as excinfo:
+        floss.main.main(["--print-completion", shell])
+    assert excinfo.value.code == 0
+
+    out = capsys.readouterr().out
+    assert out.strip()
+    # all generated scripts reference the program by name
+    assert "floss" in out
+
+
+def test_print_completion_bash(capsys):
+    """the bash script completes flags, choices, and the sample file path."""
+    with pytest.raises(SystemExit):
+        floss.main.main(["--print-completion", "bash"])
+
+    out = capsys.readouterr().out
+    assert "--string-type" in out
+    # choice values from argparse are embedded
+    assert "static stack tight decoded language all" in out
+    # the sample positional completes file paths
+    assert "_shtab_compgen_files" in out
+
+
+def test_print_completion_zsh(capsys):
+    """the zsh script uses the #compdef header so compinit registers it."""
+    with pytest.raises(SystemExit):
+        floss.main.main(["--print-completion", "zsh"])
+
+    out = capsys.readouterr().out
+    assert out.startswith("#compdef floss")
+
+
+def test_print_completion_fish(capsys):
+    """the fish script registers completions for the program."""
+    with pytest.raises(SystemExit):
+        floss.main.main(["--print-completion", "fish"])
+
+    out = capsys.readouterr().out
+    assert "complete -c floss" in out
+
+
+@pytest.mark.parametrize("shell", ["badshell", ""])
+def test_print_completion_invalid_shell(shell, capsys):
+    """an unknown shell is an argument error, not a crash."""
+    assert floss.main.main(["--print-completion", shell]) == -1

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -18,7 +18,7 @@ import pytest
 import floss.main
 
 
-@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+@pytest.mark.parametrize("shell", ["bash", "zsh", "tcsh", "fish", "powershell"])
 def test_print_completion(shell, capsys):
     """--print-completion emits a non-empty completion script and exits cleanly."""
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
Fixes #1350

Adds tab completion for FLOSS arguments via [`shtab`](https://github.com/tqdm/shtab), which generates the scripts directly from our `argparse` parser. Because they're derived from the argument definitions, flags, choice values, and file paths stay in sync automatically as the CLI evolves.

    floss --print-completion {bash,zsh,tcsh,fish,powershell}


Sample output:

```
$ floss -
--analyze-functions      -- only analyze the specified functions, hex-encoded like 0x401000, space-separate multiple functions
--color                  -- enable ANSI color codes in results, default: only during interactive session
--columns                -- columns to show in the layout view; valid values: tags, offset, structure, encoding. Default: tags, offset.
--debug              -d  -- enable debugging output on STDERR, specify multiple times to increase verbosity
--format             -f  -- select sample format, auto: (default) detect file type automatically, pe: Windows PE file, sc32: 32-bit shellcode, sc64: 64-bit shellcode
--help               -h  -- show this help message and exit
--interesting            -- exclude strings with noisy tags: #code, #code-junk, #common, #duplicate, #reloc
--json               -j  -- emit JSON instead of text
--language               -- use language-specific string extraction, auto-detect language by default, disable using 'none'
--large-file         -L  -- allow processing files larger than 64 MB
--max-strings            -- cap the emitted strings per section to the top N by relevance (highlighted, then untagged, then tagged, ascending by offset)
--minimum-length     -n  -- minimum string length
--no-section             -- do not show static strings in the given binary section(s)
--no-string-type         -- do not extract specified string type(s); valid values: static, stack, tight, decoded, language, all
--no-structure           -- do not show static strings in the given binary structure(s)
--no-tag                 -- do not show strings with the given semantic tag(s)
--plain                  -- render the classic flat list of strings without layout and tags
--print-completion       -- print shell completion script for the given shell
--query                  -- only show strings matching the given regular expression(s); repeatable, patterns are ORed
--quiet              -q  -- disable all status output on STDOUT except fatal errors
--section                -- only show static strings in the given binary section(s); e.g. .rdata
--signatures             -- path to .sig/.pat file or directory used to identify library functions, use embedded signatures by default
--string-type            -- only extract specified string type(s); valid values: static, stack, tight, decoded, language, all
--structure              -- only show static strings in the given binary structure(s); e.g. import-table, export-table, rich-header, section-header, elf-header, program-header, string-table, sy
--summary                -- emit a concise summary (metadata, counts, tag histogram, high-value strings); static-only by default unless string types are explicitly selected
--tag                    -- only show strings with the given semantic tag(s); e.g. winapi, crypto, or a tag family: crt, expert, gp, oss, winapi; run --summary to see the tags present in a spec
--verbose            -v  -- enable verbose results, e.g. including function offsets (does not affect JSON output)
--version                -- show program's version number and exit
```

## What completes

- all flags and options (`floss --string-<TAB>` offers `--string-type`)
- the `sample` positional completes file paths
- per-shell installation instructions added to [doc/usage.md](doc/usage.md)

## Notes

- `shtab` is a small pure-python dependency with no transitive deps; pinned in `requirements.txt` (`shtab==1.12.0`), loose bound in `pyproject.toml` (`shtab>=1.7`) per the library-dependency policy
- also works from PyInstaller standalone builds, where users can't pip-install extras
- parser now sets `prog="floss"` so generated scripts and usage text are stable across entry points (entry point, `python -m floss`, standalone exe)
- new tests in `tests/test_completion.py`: script generation + exit codes for bash/zsh/fish, content markers, and invalid-shell error path

cc: @mr-tz 
