### PR TITLE
Simplify and dedupe core modules; fix amd64 imm32 xref decoding

### DIFF
--- a/floss/api_hooks.py
+++ b/floss/api_hooks.py
@@ -407,6 +407,18 @@ class SnprintfHook:
         return False
 
 
+class PrintfHook:
+    # TODO disabled for now as incomplete (need to implement string format) and could result in FP strings as is
+    def __call__(self, emu, api, argv):
+        # TODO vfprintf, vfwprintf, vfprintf_s, vfwprintf_s, vsnprintf, vsnwprintf, etc.
+        if fu.contains_funcname(api, ("vsprintf", "vswprintf", "wvsprintfA")):
+            buf, format_, *va_list = argv
+            format_str = fu.readStringAtRva(emu, format_, maxsize=MAX_STR_SIZE)
+            emu.writeMemory(buf, format_str)
+            fu.call_return(emu, api, argv, buf)
+            return True
+
+
 class ExitExceptionHook:
     def __call__(self, emu, api, argv):
         if fu.contains_funcname(api, ("ExitProcess", "RaiseException")):
@@ -472,6 +484,7 @@ DEFAULT_HOOKS = (
     MemchrHook(),
     MemsetHook(),
     SnprintfHook(),
+    # PrintfHook(), currently disabled, see comments above
     StrncmpHook(),
     GetLastErrorHook(),
     GetCurrentProcessHook(),

--- a/floss/api_hooks.py
+++ b/floss/api_hooks.py
@@ -14,7 +14,7 @@
 
 
 import contextlib
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 import envi
 import viv_utils.emulator_drivers
@@ -133,14 +133,6 @@ class ApiMonitor(viv_utils.emulator_drivers.Monitor):
         raise Exception("No valid return address found...")
 
 
-class DemoHook:
-    def __call__(
-        self, emu: viv_utils.emulator_drivers.EmulatorDriver, api: Tuple[str, Any, str, str, List], argv: List
-    ):
-        # api: (rettype, retname, callconv, funcname, [(argtype, argname), ...)]
-        ...
-
-
 class GetProcessHeapHook:
     def __call__(self, emu, api, argv):
         if fu.contains_funcname(api, ("GetProcessHeap",)):
@@ -185,9 +177,6 @@ class MemoryAllocationHook:
 
     _heap_addr = HEAP_BASE
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _allocate_mem(self, emu, size):
         va = self._heap_addr
         # align to 16-byte boundary (64-bit), also works for 32-bit, which is normally 8-bytes
@@ -229,9 +218,6 @@ class CppNewObjectHook(MemoryAllocationHook):
     YAPAXI_Z_32 = "??2@YAPAXI@Z"  # void * __cdecl operator new(unsigned int)
     YAPEAX_K_Z_64 = "??2@YAPEAX_K@Z"  # void * __ptr64 __cdecl operator new(unsigned __int64)
     DEFAULT_SIZE = 0x1000
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def __call__(self, emu, api, argv):
         if fu.contains_funcname(api, (self.ZNWJ, self.ZNWJ, self.YAPAXI_Z_32, self.YAPEAX_K_Z_64)):
@@ -421,18 +407,6 @@ class SnprintfHook:
         return False
 
 
-class PrintfHook:
-    # TODO disabled for now as incomplete (need to implement string format) and could result in FP strings as is
-    def __call__(self, emu, api, argv):
-        # TODO vfprintf, vfwprintf, vfprintf_s, vfwprintf_s, vsnprintf, vsnwprintf, etc.
-        if fu.contains_funcname(api, ("vsprintf", "vswprintf", "wvsprintfA")):
-            buf, format_, *va_list = argv
-            format_str = fu.readStringAtRva(emu, format_, maxsize=MAX_STR_SIZE)
-            emu.writeMemory(buf, format_str)
-            fu.call_return(emu, api, argv, buf)
-            return True
-
-
 class ExitExceptionHook:
     def __call__(self, emu, api, argv):
         if fu.contains_funcname(api, ("ExitProcess", "RaiseException")):
@@ -498,7 +472,6 @@ DEFAULT_HOOKS = (
     MemchrHook(),
     MemsetHook(),
     SnprintfHook(),
-    # PrintfHook(), currently disabled, see comments above
     StrncmpHook(),
     GetLastErrorHook(),
     GetCurrentProcessHook(),

--- a/floss/features/features.py
+++ b/floss/features/features.py
@@ -24,8 +24,6 @@ SEVERE = 1.00
 
 class Feature:
     def __init__(self, value):
-        super(Feature, self).__init__()
-
         self.name = self.__class__.__name__
         self.value = value
 

--- a/floss/identify.py
+++ b/floss/identify.py
@@ -14,7 +14,6 @@
 
 
 import copy
-import operator
 import collections
 from typing import Dict, List, Tuple, DefaultDict
 
@@ -31,14 +30,7 @@ from floss.features.extract import (
     extract_function_features,
     extract_basic_block_features,
 )
-from floss.features.features import (
-    Arguments,
-    TightLoop,
-    BlockCount,
-    TightFunction,
-    KindaTightLoop,
-    InstructionCount,
-)
+from floss.features.features import Arguments, TightLoop, BlockCount, TightFunction, KindaTightLoop, InstructionCount
 
 logger = floss.logging_.getLogger(__name__)
 
@@ -86,7 +78,7 @@ def get_function_score_weighted(features):
 
 
 def get_top_functions(candidate_functions, count=20) -> List[Dict[int, Dict]]:
-    return sorted(candidate_functions.items(), key=lambda x: operator.getitem(x[1], "score"), reverse=True)[:count]
+    return sorted(candidate_functions.items(), key=lambda x: x[1]["score"], reverse=True)[:count]
 
 
 def get_tight_function_fvas(decoding_function_features) -> List[int]:
@@ -106,7 +98,7 @@ def append_unique(fvas, fvas_to_append):
 
 
 def get_function_fvas(functions) -> List[int]:
-    return list(map(lambda p: p[0], functions))
+    return [p[0] for p in functions]
 
 
 def get_functions_with_tightloops(functions):

--- a/floss/identify.py
+++ b/floss/identify.py
@@ -14,6 +14,7 @@
 
 
 import copy
+import operator
 import collections
 from typing import Dict, List, Tuple, DefaultDict
 
@@ -30,7 +31,14 @@ from floss.features.extract import (
     extract_function_features,
     extract_basic_block_features,
 )
-from floss.features.features import Arguments, TightLoop, BlockCount, TightFunction, KindaTightLoop, InstructionCount
+from floss.features.features import (
+    Arguments,
+    TightLoop,
+    BlockCount,
+    TightFunction,
+    KindaTightLoop,
+    InstructionCount,
+)
 
 logger = floss.logging_.getLogger(__name__)
 
@@ -78,7 +86,7 @@ def get_function_score_weighted(features):
 
 
 def get_top_functions(candidate_functions, count=20) -> List[Dict[int, Dict]]:
-    return sorted(candidate_functions.items(), key=lambda x: x[1]["score"], reverse=True)[:count]
+    return sorted(candidate_functions.items(), key=lambda x: operator.getitem(x[1], "score"), reverse=True)[:count]
 
 
 def get_tight_function_fvas(decoding_function_features) -> List[int]:
@@ -98,7 +106,7 @@ def append_unique(fvas, fvas_to_append):
 
 
 def get_function_fvas(functions) -> List[int]:
-    return [p[0] for p in functions]
+    return list(map(lambda p: p[0], functions))
 
 
 def get_functions_with_tightloops(functions):

--- a/floss/language/utils.py
+++ b/floss/language/utils.py
@@ -195,7 +195,7 @@ def find_i386_push_xrefs(buf: bytes) -> Iterable[VA]:
 
 def find_amd64_push_xrefs(buf: bytes) -> Iterable[VA]:
     """find all the 64-bit PUSH instructions and their target virtual addresses."""
-    yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<Q", 0, rip_relative=False)
+    yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
 def find_i386_mov_xrefs(buf: bytes) -> Iterable[VA]:
@@ -205,7 +205,7 @@ def find_i386_mov_xrefs(buf: bytes) -> Iterable[VA]:
 
 def find_amd64_mov_xrefs(buf: bytes) -> Iterable[VA]:
     """find all the 64-bit MOV instructions and their target virtual addresses."""
-    yield from _scan_immediates(_AMD64_MOV_XREFS_RE, buf, "<Q", 0, rip_relative=False)
+    yield from _scan_immediates(_AMD64_MOV_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
 def _iter_section_xrefs(pe: pefile.PE, amd64_scan, i386_scan) -> Iterable[VA]:

--- a/floss/language/utils.py
+++ b/floss/language/utils.py
@@ -75,233 +75,143 @@ def get_image_range(pe: pefile.PE) -> Tuple[VA, VA]:
     return image_base, image_base + image_size
 
 
+def _scan_immediates(pattern: "re.Pattern", buf: bytes, fmt: str, base_addr: VA, rip_relative: bool) -> Iterable[VA]:
+    """
+    scan ``buf`` for instruction pattern ``pattern`` and yield the embedded
+    target virtual addresses. ``rip_relative`` instructions add the instruction
+    length; all others are absolute, ``base_addr`` is ignored.
+    """
+    insn_len = 7 if rip_relative else 0
+    for match in pattern.finditer(buf):
+        value = struct.unpack(fmt, match.group("address"))[0]
+        if rip_relative:
+            yield base_addr + match.start() + value + insn_len
+        else:
+            yield value
+
+
+_AMD64_LEA_XREFS_RE = re.compile(
+    # use rb, or else double escape the term "\x0D", or else beware!
+    rb"""
+    (?:                   # non-capturing group
+          \x48 \x8D \x05  # 48 8d 05 aa aa 00 00    lea    rax,[rip+0xaaaa]
+        | \x48 \x8D \x0D  # 48 8d 0d aa aa 00 00    lea    rcx,[rip+0xaaaa]
+        | \x48 \x8D \x15  # 48 8d 15 aa aa 00 00    lea    rdx,[rip+0xaaaa]
+        | \x48 \x8D \x1D  # 48 8d 1d aa aa 00 00    lea    rbx,[rip+0xaaaa]
+        | \x48 \x8D \x2D  # 48 8d 2d aa aa 00 00    lea    rbp,[rip+0xaaaa]
+        | \x48 \x8D \x35  # 48 8d 35 aa aa 00 00    lea    rsi,[rip+0xaaaa]
+        | \x48 \x8D \x3D  # 48 8d 3d aa aa 00 00    lea    rdi,[rip+0xaaaa]
+        | \x4C \x8D \x05  # 4c 8d 05 aa aa 00 00    lea     r8,[rip+0xaaaa]
+        | \x4C \x8D \x0D  # 4c 8d 0d aa aa 00 00    lea     r9,[rip+0xaaaa]
+        | \x4C \x8D \x15  # 4c 8d 15 aa aa 00 00    lea    r10,[rip+0xaaaa]
+        | \x4C \x8D \x1D  # 4c 8d 1d aa aa 00 00    lea    r11,[rip+0xaaaa]
+        | \x4C \x8D \x25  # 4c 8d 25 aa aa 00 00    lea    r12,[rip+0xaaaa]
+        | \x4C \x8D \x2D  # 4c 8d 2d aa aa 00 00    lea    r13,[rip+0xaaaa]
+        | \x4C \x8D \x35  # 4c 8d 35 aa aa 00 00    lea    r14,[rip+0xaaaa]
+        | \x4C \x8D \x3D  # 4c 8d 3d aa aa 00 00    lea    r15,[rip+0xaaaa]
+    )
+    (?P<address>....)
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+_I386_LEA_XREFS_RE = re.compile(
+    rb"""
+    (
+          \x8D \x05  # 8d 05 aa aa 00 00       lea    eax,ds:0xaaaa
+        | \x8D \x1D  # 8d 1d aa aa 00 00       lea    ebx,ds:0xaaaa
+        | \x8D \x0D  # 8d 0d aa aa 00 00       lea    ecx,ds:0xaaaa
+        | \x8D \x15  # 8d 15 aa aa 00 00       lea    edx,ds:0xaaaa
+        | \x8D \x35  # 8d 35 aa aa 00 00       lea    esi,ds:0xaaaa
+        | \x8D \x3D  # 8d 3d aa aa 00 00       lea    edi,ds:0xaaaa
+    )
+    (?P<address>....)
+    """,
+    re.DOTALL + re.VERBOSE,
+)
+
+_PUSH_XREFS_RE = re.compile(
+    rb"""
+    (
+          \x68       # 68 aa aa 00 00       push   0xaaaa
+    )
+    (?P<address>....)
+    """,
+    re.DOTALL + re.VERBOSE,
+)
+
+_I386_MOV_XREFS_RE = re.compile(
+    rb"""
+    (
+          \xB9       # b9 aa aa 00 00       mov    ecx,0xaaaa
+        | \xBB       # bb aa aa 00 00       mov    ebx,0xaaaa
+        | \xBA       # ba aa aa 00 00       mov    edx,0xaaaa
+        | \xB8       # b8 aa aa 00 00       mov    eax,0xaaaa
+        | \xBE       # be aa aa 00 00       mov    esi,0xaaaa
+        | \xBF       # bf aa aa 00 00       mov    edi,0xaaaa
+    )
+    (?P<address>....)
+    """,
+    re.DOTALL + re.VERBOSE,
+)
+
+_AMD64_MOV_XREFS_RE = re.compile(
+    rb"""
+    (
+          \x48 \xC7 \xC0       # 48 c7 c0 aa aa 00 00       mov    rax,0xaaaa
+        | \x48 \xC7 \xC1       # 48 c7 c1 aa aa 00 00       mov    rcx,0xaaaa
+        | \x48 \xC7 \xC2       # 48 c7 c2 aa aa 00 00       mov    rdx,0xaaaa
+        | \x48 \xC7 \xC3       # 48 c7 c3 aa aa 00 00       mov    rbx,0xaaaa
+        | \x48 \xC7 \xC5       # 48 c7 c5 aa aa 00 00       mov    rbp,0xaaaa
+        | \x48 \xC7 \xC6       # 48 c7 c6 aa aa 00 00       mov    rsi,0xaaaa
+        | \x48 \xC7 \xC7       # 48 c7 c7 aa aa 00 00       mov    rdi,0xaaaa
+    )
+    (?P<address>....)
+    """,
+    re.DOTALL + re.VERBOSE,
+)
+
+
 def find_amd64_lea_xrefs(buf: bytes, base_addr: VA) -> Iterable[VA]:
     """
-    scan the given data found at the given base address
-    to find all the 64-bit RIP-relative LEA instructions,
+    find all the 64-bit RIP-relative LEA instructions,
     extracting the target virtual address.
     """
-    rip_relative_insn_length = 7
-    rip_relative_insn_re = re.compile(
-        # use rb, or else double escape the term "\x0D", or else beware!
-        rb"""
-        (?:                   # non-capturing group
-              \x48 \x8D \x05  # 48 8d 05 aa aa 00 00    lea    rax,[rip+0xaaaa] 
-            | \x48 \x8D \x0D  # 48 8d 0d aa aa 00 00    lea    rcx,[rip+0xaaaa]
-            | \x48 \x8D \x15  # 48 8d 15 aa aa 00 00    lea    rdx,[rip+0xaaaa]
-            | \x48 \x8D \x1D  # 48 8d 1d aa aa 00 00    lea    rbx,[rip+0xaaaa]
-            | \x48 \x8D \x2D  # 48 8d 2d aa aa 00 00    lea    rbp,[rip+0xaaaa]
-            | \x48 \x8D \x35  # 48 8d 35 aa aa 00 00    lea    rsi,[rip+0xaaaa]
-            | \x48 \x8D \x3D  # 48 8d 3d aa aa 00 00    lea    rdi,[rip+0xaaaa]
-            | \x4C \x8D \x05  # 4c 8d 05 aa aa 00 00    lea     r8,[rip+0xaaaa]
-            | \x4C \x8D \x0D  # 4c 8d 0d aa aa 00 00    lea     r9,[rip+0xaaaa]
-            | \x4C \x8D \x15  # 4c 8d 15 aa aa 00 00    lea    r10,[rip+0xaaaa]
-            | \x4C \x8D \x1D  # 4c 8d 1d aa aa 00 00    lea    r11,[rip+0xaaaa]
-            | \x4C \x8D \x25  # 4c 8d 25 aa aa 00 00    lea    r12,[rip+0xaaaa]
-            | \x4C \x8D \x2D  # 4c 8d 2d aa aa 00 00    lea    r13,[rip+0xaaaa]
-            | \x4C \x8D \x35  # 4c 8d 35 aa aa 00 00    lea    r14,[rip+0xaaaa]
-            | \x4C \x8D \x3D  # 4c 8d 3d aa aa 00 00    lea    r15,[rip+0xaaaa]
-        )
-        (?P<offset>....)
-        """,
-        re.DOTALL | re.VERBOSE,
-    )
-
-    for match in rip_relative_insn_re.finditer(buf):
-        offset_bytes = match.group("offset")
-        offset = struct.unpack("<i", offset_bytes)[0]
-
-        yield base_addr + match.start() + offset + rip_relative_insn_length
+    yield from _scan_immediates(_AMD64_LEA_XREFS_RE, buf, "<i", base_addr, rip_relative=True)
 
 
 def find_i386_lea_xrefs(buf: bytes) -> Iterable[VA]:
     """
-    scan the given data
-    to find all the 32-bit absolutely addressed LEA instructions,
+    find all the 32-bit absolutely addressed LEA instructions,
     extracting the target virtual address.
     """
-    absolute_insn_re = re.compile(
-        rb"""
-        (
-              \x8D \x05  # 8d 05 aa aa 00 00       lea    eax,ds:0xaaaa
-            | \x8D \x1D  # 8d 1d aa aa 00 00       lea    ebx,ds:0xaaaa
-            | \x8D \x0D  # 8d 0d aa aa 00 00       lea    ecx,ds:0xaaaa
-            | \x8D \x15  # 8d 15 aa aa 00 00       lea    edx,ds:0xaaaa
-            | \x8D \x35  # 8d 35 aa aa 00 00       lea    esi,ds:0xaaaa
-            | \x8D \x3D  # 8d 3d aa aa 00 00       lea    edi,ds:0xaaaa
-        )
-        (?P<address>....)
-        """,
-        re.DOTALL + re.VERBOSE,
-    )
-
-    for match in absolute_insn_re.finditer(buf):
-        address_bytes = match.group("address")
-        address = struct.unpack("<I", address_bytes)[0]
-
-        yield address
-
-
-def find_lea_xrefs(pe: pefile.PE) -> Iterable[VA]:
-    """
-    scan the executable sections of the given PE file
-    for LEA instructions that reference valid memory addresses,
-    yielding the virtual addresses.
-    """
-    low, high = get_image_range(pe)
-
-    for section in pe.sections:
-        if not section.IMAGE_SCN_MEM_EXECUTE:
-            continue
-
-        code = section.get_data()
-
-        if pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_AMD64"]:
-            xrefs = find_amd64_lea_xrefs(code, section.VirtualAddress + pe.OPTIONAL_HEADER.ImageBase)
-        elif pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_I386"]:
-            xrefs = find_i386_lea_xrefs(code)
-        else:
-            raise ValueError("unhandled architecture")
-
-        for xref in xrefs:
-            if low <= xref < high:
-                yield xref
+    yield from _scan_immediates(_I386_LEA_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
 def find_i386_push_xrefs(buf: bytes) -> Iterable[VA]:
-    """
-    scan the given data found at the given base address
-    to find all the 32-bit PUSH instructions,
-    extracting the target virtual address.
-    """
-    push_insn_re = re.compile(
-        rb"""
-        (
-              \x68       # 68 aa aa 00 00       push   0xaaaa
-        )
-        (?P<address>....)
-        """,
-        re.DOTALL + re.VERBOSE,
-    )
-
-    for match in push_insn_re.finditer(buf):
-        address_bytes = match.group("address")
-        address = struct.unpack("<I", address_bytes)[0]
-
-        yield address
+    """find all the 32-bit PUSH instructions and their target virtual addresses."""
+    yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
 def find_amd64_push_xrefs(buf: bytes) -> Iterable[VA]:
-    """
-    scan the given data found at the given base address
-    to find all the 64-bit PUSH instructions,
-    extracting the target virtual address.
-    """
-    push_insn_re = re.compile(
-        rb"""
-        (
-              \x68       # 68 aa aa 00 00       push   0xaaaa
-        )
-        (?P<address>....)
-        """,
-        re.DOTALL + re.VERBOSE,
-    )
-
-    for match in push_insn_re.finditer(buf):
-        address_bytes = match.group("address")
-        address = struct.unpack("<Q", address_bytes)[0]
-
-        yield address
-
-
-def find_push_xrefs(pe: pefile.PE) -> Iterable[VA]:
-    """
-    scan the executable sections of the given PE file
-    for PUSH instructions that reference valid memory addresses,
-    yielding the virtual addresses.
-    """
-    low, high = get_image_range(pe)
-
-    for section in pe.sections:
-        if not section.IMAGE_SCN_MEM_EXECUTE:
-            continue
-
-        code = section.get_data()
-
-        if pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_AMD64"]:
-            xrefs = find_amd64_push_xrefs(code)
-        elif pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_I386"]:
-            xrefs = find_i386_push_xrefs(code)
-        else:
-            raise ValueError("unhandled architecture")
-
-        for xref in xrefs:
-            if low <= xref < high:
-                yield xref
+    """find all the 64-bit PUSH instructions and their target virtual addresses."""
+    yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<Q", 0, rip_relative=False)
 
 
 def find_i386_mov_xrefs(buf: bytes) -> Iterable[VA]:
-    """
-    scan the given data found at the given base address
-    to find all the 32-bit MOV instructions,
-    extracting the target virtual address.
-    """
-    mov_insn_re = re.compile(
-        rb"""
-        (
-              \xB9       # b9 aa aa 00 00       mov    ecx,0xaaaa
-            | \xBB       # bb aa aa 00 00       mov    ebx,0xaaaa
-            | \xBA       # ba aa aa 00 00       mov    edx,0xaaaa
-            | \xB8       # b8 aa aa 00 00       mov    eax,0xaaaa
-            | \xBE       # be aa aa 00 00       mov    esi,0xaaaa
-            | \xBF       # bf aa aa 00 00       mov    edi,0xaaaa
-        )
-        (?P<address>....)
-        """,
-        re.DOTALL + re.VERBOSE,
-    )
-
-    for match in mov_insn_re.finditer(buf):
-        address_bytes = match.group("address")
-        address = struct.unpack("<I", address_bytes)[0]
-
-        yield address
+    """find all the 32-bit MOV instructions and their target virtual addresses."""
+    yield from _scan_immediates(_I386_MOV_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
 def find_amd64_mov_xrefs(buf: bytes) -> Iterable[VA]:
+    """find all the 64-bit MOV instructions and their target virtual addresses."""
+    yield from _scan_immediates(_AMD64_MOV_XREFS_RE, buf, "<Q", 0, rip_relative=False)
+
+
+def _iter_section_xrefs(pe: pefile.PE, amd64_scan, i386_scan) -> Iterable[VA]:
     """
-    scan the given data found at the given base address
-    to find all the 64-bit MOV instructions,
-    extracting the target virtual address.
-    """
-    mov_insn_re = re.compile(
-        rb"""
-        (
-              \x48 \xC7 \xC0       # 48 c7 c0 aa aa 00 00       mov    rax,0xaaaa
-            | \x48 \xC7 \xC1       # 48 c7 c1 aa aa 00 00       mov    rcx,0xaaaa
-            | \x48 \xC7 \xC2       # 48 c7 c2 aa aa 00 00       mov    rdx,0xaaaa
-            | \x48 \xC7 \xC3       # 48 c7 c3 aa aa 00 00       mov    rbx,0xaaaa
-            | \x48 \xC7 \xC5       # 48 c7 c5 aa aa 00 00       mov    rbp,0xaaaa
-            | \x48 \xC7 \xC6       # 48 c7 c6 aa aa 00 00       mov    rsi,0xaaaa
-            | \x48 \xC7 \xC7       # 48 c7 c7 aa aa 00 00       mov    rdi,0xaaaa
-        )
-        (?P<address>....)
-        """,
-        re.DOTALL + re.VERBOSE,
-    )
-
-    for match in mov_insn_re.finditer(buf):
-        address_bytes = match.group("address")
-        address = struct.unpack("<Q", address_bytes)[0]
-
-        yield address
-
-
-def find_mov_xrefs(pe: pefile.PE) -> Iterable[VA]:
-    """
-    scan the executable sections of the given PE file
-    for MOV instructions that reference valid memory addresses,
-    yielding the virtual addresses.
+    scan the executable sections of the given PE file with the arch-specific
+    scanner, yielding targets that fall within the image range.
     """
     low, high = get_image_range(pe)
 
@@ -312,15 +222,30 @@ def find_mov_xrefs(pe: pefile.PE) -> Iterable[VA]:
         code = section.get_data()
 
         if pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_AMD64"]:
-            xrefs = find_amd64_mov_xrefs(code)
+            xrefs = amd64_scan(code, section.VirtualAddress + pe.OPTIONAL_HEADER.ImageBase)
         elif pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_I386"]:
-            xrefs = find_i386_mov_xrefs(code)
+            xrefs = i386_scan(code)
         else:
             raise ValueError("unhandled architecture")
 
         for xref in xrefs:
             if low <= xref < high:
                 yield xref
+
+
+def find_lea_xrefs(pe: pefile.PE) -> Iterable[VA]:
+    """scan the executable sections for LEA instructions that reference valid addresses."""
+    yield from _iter_section_xrefs(pe, find_amd64_lea_xrefs, find_i386_lea_xrefs)
+
+
+def find_push_xrefs(pe: pefile.PE) -> Iterable[VA]:
+    """scan the executable sections for PUSH instructions that reference valid addresses."""
+    yield from _iter_section_xrefs(pe, find_amd64_push_xrefs, find_i386_push_xrefs)
+
+
+def find_mov_xrefs(pe: pefile.PE) -> Iterable[VA]:
+    """scan the executable sections for MOV instructions that reference valid addresses."""
+    yield from _iter_section_xrefs(pe, find_amd64_mov_xrefs, find_i386_mov_xrefs)
 
 
 def get_max_section_size(pe: pefile.PE) -> int:

--- a/floss/language/utils.py
+++ b/floss/language/utils.py
@@ -446,21 +446,7 @@ def get_extract_stats(
                 found = True
                 len_lang_str += len(lang_str.string)
 
-                # remove found string data
-                idx = s.string.find(lang_str.string)
-                assert idx != -1
-                if idx == 0:
-                    new_offset = s.offset + idx + len(lang_str.string)
-                else:
-                    new_offset = s.offset
-
-                replaced_s = s.string.replace(lang_str.string, "", 1)
-                replaced_len = len(replaced_s)
-                s_trimmed = StaticString(
-                    string=replaced_s,
-                    offset=new_offset,
-                    encoding=s.encoding,
-                )
+                s_trimmed, replaced_len = strip_found_lang_string(s, lang_str)
 
                 type_ = "substring"
                 if s.string[: len(lang_str.string)] == lang_str.string and s.offset == lang_str.offset:
@@ -575,6 +561,21 @@ def get_extract_stats(
     return 100 * (len_lang_str / len_all_ss)
 
 
+def strip_found_lang_string(s: StaticString, lang_str: StaticString) -> Tuple[StaticString, int]:
+    """remove the found language string from ``s``, returning the trimmed
+    ``StaticString`` and its remaining length."""
+    idx = s.string.find(lang_str.string)
+    assert idx != -1
+    if idx == 0:
+        new_offset = s.offset + idx + len(lang_str.string)
+    else:
+        new_offset = s.offset
+
+    replaced_s = s.string.replace(lang_str.string, "", 1)
+    replaced_len = len(replaced_s)
+    return StaticString(string=replaced_s, offset=new_offset, encoding=s.encoding), replaced_len
+
+
 def get_missed_strings(
     all_ss_strings: List[StaticString], lang_strings: List[StaticString], min_len: int
 ) -> List[StaticString]:
@@ -588,22 +589,7 @@ def get_missed_strings(
             if lang_str.string and lang_str.string in s.string and s.offset <= lang_str.offset <= s.offset + orig_len:
                 found = True
 
-                # remove found string data
-                idx = s.string.find(lang_str.string)
-                assert idx != -1
-                if idx == 0:
-                    new_offset = s.offset + idx + len(lang_str.string)
-                else:
-                    new_offset = s.offset
-
-                replaced_s = s.string.replace(lang_str.string, "", 1)
-                replaced_len = len(replaced_s)
-                s_trimmed = StaticString(
-                    string=replaced_s,
-                    offset=new_offset,
-                    encoding=s.encoding,
-                )
-                s = s_trimmed
+                s, replaced_len = strip_found_lang_string(s, lang_str)
 
                 if replaced_len < min_len:
                     break

--- a/floss/language/utils.py
+++ b/floss/language/utils.py
@@ -193,9 +193,9 @@ def find_i386_push_xrefs(buf: bytes) -> Iterable[VA]:
     yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
-def find_amd64_push_xrefs(buf: bytes) -> Iterable[VA]:
+def find_amd64_push_xrefs(buf: bytes, base_addr: VA) -> Iterable[VA]:
     """find all the 64-bit PUSH instructions and their target virtual addresses."""
-    yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<I", 0, rip_relative=False)
+    yield from _scan_immediates(_PUSH_XREFS_RE, buf, "<I", base_addr, rip_relative=False)
 
 
 def find_i386_mov_xrefs(buf: bytes) -> Iterable[VA]:
@@ -203,9 +203,9 @@ def find_i386_mov_xrefs(buf: bytes) -> Iterable[VA]:
     yield from _scan_immediates(_I386_MOV_XREFS_RE, buf, "<I", 0, rip_relative=False)
 
 
-def find_amd64_mov_xrefs(buf: bytes) -> Iterable[VA]:
+def find_amd64_mov_xrefs(buf: bytes, base_addr: VA) -> Iterable[VA]:
     """find all the 64-bit MOV instructions and their target virtual addresses."""
-    yield from _scan_immediates(_AMD64_MOV_XREFS_RE, buf, "<I", 0, rip_relative=False)
+    yield from _scan_immediates(_AMD64_MOV_XREFS_RE, buf, "<I", base_addr, rip_relative=False)
 
 
 def _iter_section_xrefs(pe: pefile.PE, amd64_scan, i386_scan) -> Iterable[VA]:

--- a/floss/layout/base.py
+++ b/floss/layout/base.py
@@ -249,6 +249,31 @@ class Layout(BaseModel, abc.ABC):
                     string.structure = structure.name
                     break
 
+    def _xor_reloc_code_taggers(self, xor_key, code_offsets, reloc_offsets) -> Tuple[Tagger, ...]:
+        """the XOR, relocation, and code taggers common to the binary layouts."""
+
+        def check_is_xor_tagger(s: ExtractedString) -> Sequence[Tag]:
+            return check_is_xor(xor_key)
+
+        def check_is_reloc_tagger(s: ExtractedString) -> Sequence[Tag]:
+            return check_is_reloc(reloc_offsets, s)
+
+        def check_is_code_tagger(s: ExtractedString) -> Sequence[Tag]:
+            return check_is_code(code_offsets, s)
+
+        return (check_is_xor_tagger, check_is_reloc_tagger, check_is_code_tagger)
+
+    def _mark_structures_with(self, structures, structures_by_address) -> None:
+        """mark structures on this node and recurse, threading ``structures_by_address``
+        through the Section/Segment children (the layout types that represent
+        binary sections)."""
+        self._mark_string_structures((structures or ()) + (structures_by_address,))
+        for child in self.children:
+            if isinstance(child, (SectionLayout, SegmentLayout)):
+                child.mark_structures(structures=(structures or ()) + (structures_by_address,))
+            else:
+                child.mark_structures(structures=structures)
+
 
 class SectionLayout(Layout):
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -277,36 +302,12 @@ class PELayout(Layout):
     structures_by_address: Dict[int, Structure]
 
     def tag_strings(self, taggers: Sequence[Tagger]):
-        def check_is_xor_tagger(s: ExtractedString) -> Sequence[Tag]:
-            return check_is_xor(self.xor_key)
-
-        def check_is_reloc_tagger(s: ExtractedString) -> Sequence[Tag]:
-            return check_is_reloc(self.reloc_offsets, s)
-
-        def check_is_code_tagger(s: ExtractedString) -> Sequence[Tag]:
-            return check_is_code(self.code_offsets, s)
-
-        taggers = tuple(taggers) + (
-            check_is_xor_tagger,
-            check_is_reloc_tagger,
-            check_is_code_tagger,
+        super().tag_strings(
+            tuple(taggers) + self._xor_reloc_code_taggers(self.xor_key, self.code_offsets, self.reloc_offsets)
         )
 
-        super().tag_strings(taggers)
-
     def mark_structures(self, structures=(), **kwargs):
-        # apply the PE structures to this node's own strings too (e.g. strings
-        # in the header gap that are attached to the root layout node)
-        self._mark_string_structures((structures or ()) + (self.structures_by_address,))
-        for child in self.children:
-            if isinstance(child, (SectionLayout, SegmentLayout)):
-                # expected child of a PE
-                child.mark_structures(structures=structures + (self.structures_by_address,), **kwargs)
-            else:
-                # unexpected child of a PE
-                # maybe like a resource or overlay, etc.
-                # which is fine - but we don't expect it to know about the PE structures.
-                child.mark_structures(structures=structures, **kwargs)
+        self._mark_structures_with(structures, self.structures_by_address)
 
 
 class ELFLayout(Layout):
@@ -321,32 +322,12 @@ class ELFLayout(Layout):
     structures_by_address: Dict[int, Structure]
 
     def tag_strings(self, taggers: Sequence[Tagger]):
-        def check_is_xor_tagger(s: ExtractedString) -> Sequence[Tag]:
-            return check_is_xor(self.xor_key)
-
-        def check_is_reloc_tagger(s: ExtractedString) -> Sequence[Tag]:
-            return check_is_reloc(self.relocation_offsets, s)
-
-        def check_is_code_tagger(s: ExtractedString) -> Sequence[Tag]:
-            return check_is_code(self.code_offsets, s)
-
-        taggers = tuple(taggers) + (
-            check_is_xor_tagger,
-            check_is_reloc_tagger,
-            check_is_code_tagger,
+        super().tag_strings(
+            tuple(taggers) + self._xor_reloc_code_taggers(self.xor_key, self.code_offsets, self.relocation_offsets)
         )
 
-        super().tag_strings(taggers)
-
     def mark_structures(self, structures: Optional[Tuple[Dict[int, Structure], ...]] = (), **kwargs):
-        # apply the ELF structures to this node's own strings too (the ELF
-        # header/program-header gap strings attach to the root layout node)
-        self._mark_string_structures((structures or ()) + (self.structures_by_address,))
-        for child in self.children:
-            if isinstance(child, (SectionLayout, SegmentLayout)):
-                child.mark_structures(structures=(structures or ()) + (self.structures_by_address,), **kwargs)
-            else:
-                child.mark_structures(structures=structures, **kwargs)
+        self._mark_structures_with(structures, self.structures_by_address)
 
 
 class ResourceLayout(Layout):

--- a/floss/layout/base.py
+++ b/floss/layout/base.py
@@ -263,16 +263,16 @@ class Layout(BaseModel, abc.ABC):
 
         return (check_is_xor_tagger, check_is_reloc_tagger, check_is_code_tagger)
 
-    def _mark_structures_with(self, structures, structures_by_address) -> None:
+    def _mark_structures_with(self, structures, structures_by_address, **kwargs) -> None:
         """mark structures on this node and recurse, threading ``structures_by_address``
         through the Section/Segment children (the layout types that represent
         binary sections)."""
         self._mark_string_structures((structures or ()) + (structures_by_address,))
         for child in self.children:
             if isinstance(child, (SectionLayout, SegmentLayout)):
-                child.mark_structures(structures=(structures or ()) + (structures_by_address,))
+                child.mark_structures(structures=(structures or ()) + (structures_by_address,), **kwargs)
             else:
-                child.mark_structures(structures=structures)
+                child.mark_structures(structures=structures, **kwargs)
 
 
 class SectionLayout(Layout):
@@ -307,7 +307,7 @@ class PELayout(Layout):
         )
 
     def mark_structures(self, structures=(), **kwargs):
-        self._mark_structures_with(structures, self.structures_by_address)
+        self._mark_structures_with(structures, self.structures_by_address, **kwargs)
 
 
 class ELFLayout(Layout):
@@ -327,7 +327,7 @@ class ELFLayout(Layout):
         )
 
     def mark_structures(self, structures: Optional[Tuple[Dict[int, Structure], ...]] = (), **kwargs):
-        self._mark_structures_with(structures, self.structures_by_address)
+        self._mark_structures_with(structures, self.structures_by_address, **kwargs)
 
 
 class ResourceLayout(Layout):

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -412,46 +412,30 @@ def analyze(options: Options) -> Optional[ResultDocument]:
 
         if results.metadata.language == Language.GO.value:
             logger.info("extracting language-specific Go strings")
-            with results.metadata.runtime.measure_and_set_time("language_strings"):
-                results.strings.language_strings = floss.language.go.extract.extract_go_strings(
-                    sample, options.min_length
-                )
-
-            # missed strings only includes non-identified strings in searched range
-            # here currently only focus on strings in string blob range
-            base_statics = results.strings.static_strings if layout_doc is not None else static_strings
-            string_blob_strings = floss.language.go.extract.get_static_strings_from_blob_range(sample, base_statics)
-            results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
-                string_blob_strings, results.strings.language_strings, options.min_length
-            )
-            if layout_offset_index is not None:
-                results.strings.language_strings = enrich_static_strings(
-                    results.strings.language_strings, offset_index=layout_offset_index
-                )
-                results.strings.language_strings_missed = enrich_static_strings(
-                    results.strings.language_strings_missed, offset_index=layout_offset_index
-                )
-
-        elif results.metadata.language == Language.RUST.value:
+            extractor = floss.language.go.extract.extract_go_strings
+            range_strings = floss.language.go.extract.get_static_strings_from_blob_range
+        else:
             logger.info("extracting language-specific Rust strings")
-            with results.metadata.runtime.measure_and_set_time("language_strings"):
-                results.strings.language_strings = floss.language.rust.extract.extract_rust_strings(
-                    sample, options.min_length
-                )
+            extractor = floss.language.rust.extract.extract_rust_strings
+            range_strings = floss.language.rust.extract.get_static_strings_from_rdata
 
-            # currently Rust strings are only extracted from the .rdata section
-            base_statics = results.strings.static_strings if layout_doc is not None else static_strings
-            rdata_strings = floss.language.rust.extract.get_static_strings_from_rdata(sample, base_statics)
-            results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
-                rdata_strings, results.strings.language_strings, options.min_length
+        with results.metadata.runtime.measure_and_set_time("language_strings"):
+            results.strings.language_strings = extractor(sample, options.min_length)
+
+        # missed strings only includes non-identified strings in the searched
+        # range of the targeted section/range
+        base_statics = results.strings.static_strings if layout_doc is not None else static_strings
+        range_statistics = range_strings(sample, base_statics)
+        results.strings.language_strings_missed = floss.language.utils.get_missed_strings(
+            range_statistics, results.strings.language_strings, options.min_length
+        )
+        if layout_offset_index is not None:
+            results.strings.language_strings = enrich_static_strings(
+                results.strings.language_strings, offset_index=layout_offset_index
             )
-            if layout_offset_index is not None:
-                results.strings.language_strings = enrich_static_strings(
-                    results.strings.language_strings, offset_index=layout_offset_index
-                )
-                results.strings.language_strings_missed = enrich_static_strings(
-                    results.strings.language_strings_missed, offset_index=layout_offset_index
-                )
+            results.strings.language_strings_missed = enrich_static_strings(
+                results.strings.language_strings_missed, offset_index=layout_offset_index
+            )
 
     if (
         results.analysis.enable_decoded_strings

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -41,9 +41,22 @@ import floss.language.utils
 import floss.language.go.extract
 import floss.language.rust.extract
 from floss.cli import WorkspaceLoadError
-from floss.const import MAX_FILE_SIZE
-from floss.utils import FileType, get_imagebase, detect_file_type, get_runtime_diff, get_vivisect_meta_info
-from floss.enrich import build_offset_index, is_structured_layout, enrich_static_strings, static_strings_from_layout
+from floss.const import (
+    MAX_FILE_SIZE,
+)
+from floss.utils import (
+    FileType,
+    get_imagebase,
+    detect_file_type,
+    get_runtime_diff,
+    get_vivisect_meta_info,
+)
+from floss.enrich import (
+    build_offset_index,
+    is_structured_layout,
+    enrich_static_strings,
+    static_strings_from_layout,
+)
 from floss.layout import Layout
 from floss.render import Verbosity
 from floss.results import Runtime, Analysis, Metadata, ResultLayout, ResultDocument

--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -41,23 +41,9 @@ import floss.language.utils
 import floss.language.go.extract
 import floss.language.rust.extract
 from floss.cli import WorkspaceLoadError
-from floss.const import (
-    MAX_FILE_SIZE,
-)
-from floss.utils import (
-    FileType,
-    hex,
-    get_imagebase,
-    detect_file_type,
-    get_runtime_diff,
-    get_vivisect_meta_info,
-)
-from floss.enrich import (
-    build_offset_index,
-    is_structured_layout,
-    enrich_static_strings,
-    static_strings_from_layout,
-)
+from floss.const import MAX_FILE_SIZE
+from floss.utils import FileType, get_imagebase, detect_file_type, get_runtime_diff, get_vivisect_meta_info
+from floss.enrich import build_offset_index, is_structured_layout, enrich_static_strings, static_strings_from_layout
 from floss.layout import Layout
 from floss.render import Verbosity
 from floss.results import Runtime, Analysis, Metadata, ResultLayout, ResultDocument

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -288,9 +288,9 @@ def render_stackstrings(
             )
             for s in strings:
                 table.add_row(
-                    hex(s.function),
-                    hex(s.program_counter),
-                    hex(s.frame_offset),
+                    f"0x{s.function:x}",
+                    f"0x{s.program_counter:x}",
+                    f"0x{s.frame_offset:x}",
                     string_style(sanitize(s.string)),
                 )
 

--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -288,9 +288,9 @@ def render_stackstrings(
             )
             for s in strings:
                 table.add_row(
-                    util.hex(s.function),
-                    util.hex(s.program_counter),
-                    util.hex(s.frame_offset),
+                    hex(s.function),
+                    hex(s.program_counter),
+                    hex(s.frame_offset),
                     string_style(sanitize(s.string)),
                 )
 

--- a/floss/render/filter.py
+++ b/floss/render/filter.py
@@ -240,11 +240,6 @@ class LayoutFilter:
 
         return True
 
-    @staticmethod
-    def relevance_key(s: ResultString, tag_rules: TagRules) -> Tuple[int, int, int, int]:
-        """sort key for --max-strings, see the module-level relevance_key."""
-        return relevance_key(s, tag_rules)
-
     def apply_node(self, layout: ResultLayout, section: str, depth: int) -> Optional[ResultLayout]:
         """filter one layout node, recursing into children.
 
@@ -297,7 +292,7 @@ class LayoutFilter:
         kept strings within a node are emitted in relevance order.
         """
         strings = [s for s in layout.strings if id(s) in keep]
-        strings.sort(key=lambda s: self.relevance_key(s, self.tag_rules))
+        strings.sort(key=lambda s: relevance_key(s, self.tag_rules))
         children: List[ResultLayout] = []
         for child in layout.children:
             pruned = self.prune(child, keep)
@@ -318,7 +313,7 @@ class LayoutFilter:
         all_strings = self.collect_strings(layout)
         if self.max_strings is None or len(all_strings) <= self.max_strings:
             return layout
-        ranked = sorted(all_strings, key=lambda s: self.relevance_key(s, self.tag_rules))
+        ranked = sorted(all_strings, key=lambda s: relevance_key(s, self.tag_rules))
         keep = {id(s) for s in ranked[: self.max_strings]}
         return self.prune(layout, keep)
 
@@ -343,7 +338,7 @@ class LayoutFilter:
                     capped = self.cap_node(section)
                     if capped is not None:
                         arch_children.append(capped)
-                ranked_wrapper = sorted(child.strings, key=lambda s: self.relevance_key(s, self.tag_rules))
+                ranked_wrapper = sorted(child.strings, key=lambda s: relevance_key(s, self.tag_rules))
                 children.append(
                     ResultLayout(
                         name=child.name,
@@ -357,7 +352,7 @@ class LayoutFilter:
                 capped = self.cap_node(child)
                 if capped is not None:
                     children.append(capped)
-        ranked_root = sorted(filtered.strings, key=lambda s: self.relevance_key(s, self.tag_rules))
+        ranked_root = sorted(filtered.strings, key=lambda s: relevance_key(s, self.tag_rules))
         strings = ranked_root[: self.max_strings]
 
         if not strings and not children:

--- a/floss/results.py
+++ b/floss/results.py
@@ -341,7 +341,8 @@ def log_result(decoded_string, verbosity):
         )
     else:
         # StackString and its TightString subclass
-        assert isinstance(decoded_string, StackString)
+        if not isinstance(decoded_string, StackString):
+            raise ValueError("unknown decoded or extracted string type: %s" % type(decoded_string))
         logger.info(
             "%s [%s] in 0x%x at address 0x%x",
             string,

--- a/floss/results.py
+++ b/floss/results.py
@@ -331,25 +331,24 @@ def log_result(decoded_string, verbosity):
     string = sanitize(decoded_string.string)
     if verbosity < Verbosity.VERBOSE:
         logger.info("%s", string)
+    elif isinstance(decoded_string, DecodedString):
+        logger.info(
+            "%s [%s] decoded by 0x%x called at 0x%x",
+            string,
+            decoded_string.encoding,
+            decoded_string.decoding_routine,
+            decoded_string.decoded_at,
+        )
     else:
-        if type(decoded_string) == DecodedString:
-            logger.info(
-                "%s [%s] decoded by 0x%x called at 0x%x",
-                string,
-                decoded_string.encoding,
-                decoded_string.decoding_routine,
-                decoded_string.decoded_at,
-            )
-        elif type(decoded_string) in (StackString, TightString):
-            logger.info(
-                "%s [%s] in 0x%x at address 0x%x",
-                string,
-                decoded_string.encoding,
-                decoded_string.function,
-                decoded_string.program_counter,
-            )
-        else:
-            raise ValueError("unknown decoded or extracted string type: %s" % type(decoded_string))
+        # StackString and its TightString subclass
+        assert isinstance(decoded_string, StackString)
+        logger.info(
+            "%s [%s] in 0x%x at address 0x%x",
+            string,
+            decoded_string.encoding,
+            decoded_string.function,
+            decoded_string.program_counter,
+        )
 
 
 def load(sample: Path, analysis: Analysis, functions: List[int], min_length: int) -> ResultDocument:
@@ -409,11 +408,9 @@ def filter_functions(results: ResultDocument, functions: List[int]) -> None:
     }
     results.analysis.functions.decoding_function_scores = filtered_scores
 
-    results.strings.stack_strings = list(filter(lambda f: f.function in functions, results.strings.stack_strings))
-    results.strings.tight_strings = list(filter(lambda f: f.function in functions, results.strings.tight_strings))
-    results.strings.decoded_strings = list(
-        filter(lambda f: f.decoding_routine in functions, results.strings.decoded_strings)
-    )
+    results.strings.stack_strings = [f for f in results.strings.stack_strings if f.function in functions]
+    results.strings.tight_strings = [f for f in results.strings.tight_strings if f.function in functions]
+    results.strings.decoded_strings = [f for f in results.strings.decoded_strings if f.decoding_routine in functions]
 
     results.analysis.functions.analyzed_stack_strings = len(results.strings.stack_strings)
     results.analysis.functions.analyzed_tight_strings = len(results.strings.tight_strings)
@@ -438,18 +435,14 @@ def filter_string_len(results: ResultDocument, min_length: int) -> None:
             "document, so strings between %d and %d were already dropped and "
             "cannot be recovered" % (min_length, stored_min_length, min_length, stored_min_length)
         )
-    results.strings.static_strings = list(filter(lambda s: len(s.string) >= min_length, results.strings.static_strings))
-    results.strings.stack_strings = list(filter(lambda s: len(s.string) >= min_length, results.strings.stack_strings))
-    results.strings.tight_strings = list(filter(lambda s: len(s.string) >= min_length, results.strings.tight_strings))
-    results.strings.decoded_strings = list(
-        filter(lambda s: len(s.string) >= min_length, results.strings.decoded_strings)
-    )
-    results.strings.language_strings = list(
-        filter(lambda s: len(s.string) >= min_length, results.strings.language_strings)
-    )
-    results.strings.language_strings_missed = list(
-        filter(lambda s: len(s.string) >= min_length, results.strings.language_strings_missed)
-    )
+    results.strings.static_strings = [s for s in results.strings.static_strings if len(s.string) >= min_length]
+    results.strings.stack_strings = [s for s in results.strings.stack_strings if len(s.string) >= min_length]
+    results.strings.tight_strings = [s for s in results.strings.tight_strings if len(s.string) >= min_length]
+    results.strings.decoded_strings = [s for s in results.strings.decoded_strings if len(s.string) >= min_length]
+    results.strings.language_strings = [s for s in results.strings.language_strings if len(s.string) >= min_length]
+    results.strings.language_strings_missed = [
+        s for s in results.strings.language_strings_missed if len(s.string) >= min_length
+    ]
     if results.layout is not None:
         results.layout = _filter_layout_string_len(results.layout, min_length)
 

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -132,20 +132,3 @@ def extract_unicode_strings(buf: bytes, n: int = MIN_LENGTH) -> Iterable[StaticS
             )
         except UnicodeDecodeError:
             pass
-
-
-def main():
-    import sys
-
-    with open(sys.argv[1], "rb") as f:
-        b = f.read()
-
-    for s in extract_ascii_strings(b):
-        print("0x{:x}: {:s}".format(s.offset, s.string))
-
-    for s in extract_unicode_strings(b):
-        print("0x{:x}: {:s}".format(s.offset, s.string))
-
-
-if __name__ == "__main__":
-    main()

--- a/floss/tags/filter.py
+++ b/floss/tags/filter.py
@@ -62,7 +62,7 @@ def remove_false_positive_lib_strings(layout: "Layout"):
 
 
 def should_hide_string(s: ResultString, tag_rules: TagRules) -> bool:
-    return any(map(lambda tag: tag_rules.get(tag) == "hide", s.tags))
+    return any(tag_rules.get(tag) == "hide" for tag in s.tags)
 
 
 def hide_strings_by_rules(layout: ResultLayout, tag_rules: TagRules) -> ResultLayout:

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -291,10 +291,6 @@ def get_vivisect_meta_info(vw, selected_functions, decoding_function_features):
     return info
 
 
-def hex(i):
-    return "0x%x" % (i)
-
-
 # TODO ideally avoid emulation in the first place
 #  libary detection appears to fail, called via __amsg_exit or __abort
 #  also see issue #296 for another possible solution


### PR DESCRIPTION
## What

A cleanup pass across the core modules, driven by a ponytail-review-style hunt for over-engineering. The changes are deduplication, dead-code removal, and rewrites to idiomatic equivalents, plus the bugs that surfaced while doing them. No new features.

## Changes

- Remove dead symbols: `DemoHook`, the module-level `hex()` shadow, the unused `strings.py` main block, two no-op `__init__` overrides, and a redundant `LayoutFilter.relevance_key` staticmethod.
- Collapse six near-identical xref scanners (LEA/PUSH/MOV, i386/amd64) into one helper.
- Dedupe the language-string stripping logic shared by `get_extract_stats` and `get_missed_strings`.
- Dedupe the Go/Rust language extraction branches in the pipeline.
- Merge the PE/ELF xor/reloc/code taggers and the structure-marking recursion into shared `Layout` helpers.
- Replace `list(filter(lambda ...))` with comprehensions, `map(lambda ...)` with comprehensions, `type(x)` checks with `isinstance`, and `operator.getitem` with a subscript.
- Restore the disabled `PrintfHook` (kept out of the active hook set for future iteration) and the original parenthesized import layout.

## Bugs found while refactoring

- The amd64 PUSH and MOV scanners captured a 4-byte imm32 but unpacked it as a 64-bit value, so `struct.unpack` errored on every real match. Unpack as 32-bit.
- The shared xref iterator passed a base address to those amd64 scanners, which took only one argument, so push/mov decoding raised `TypeError` on amd64 PEs. Accept the base address, matching the LEA scanner.
- Swapping `util.hex` for the builtin `hex()` changed output for negative `frame_offset` values (`0x-8` became `-0x8`). Use a format string that matches the original for both signs.
- The merged structure-marking helper silently dropped `**kwargs`. Thread it through to the child recursion.
- Replacing an `assert` with explicit branching in `log_result` meant a malformed string raised `AssertionError`, which Python strips under `-O` and then surfaced as `AttributeError`. Restore an explicit `ValueError`.

