### PR TITLE
8.8 High (RCE) Arbitrary code execution in FLOSS via implicit `.viv` workspace loading

### DIFF
--- a/floss/pipeline.py
+++ b/floss/pipeline.py
@@ -137,6 +137,18 @@ def select_functions(vw, asked_functions: Optional[List[int]]) -> Set[int]:
     return asked_functions_
 
 
+def _load_workspace_from_file(sample_path: Path) -> VivWorkspace:
+    # getWorkspace() implicitly loads adjacent .viv files; FLOSS must parse only the requested, untrusted sample.
+    vw = VivWorkspace()
+    vw.verbose = False
+    pe_config = vw.config.getSubConfig("viv").getSubConfig("parsers").getSubConfig("pe")
+    pe_config["loadresources"] = True
+    pe_config["nx"] = True
+    vw.loadFromFile(str(sample_path))
+    viv_utils.setVwVivisectLibraryVersion(vw)
+    return vw
+
+
 def load_vw(
     sample_path: Path,
     format: str,
@@ -161,7 +173,7 @@ def load_vw(
     elif format == "sc64":
         vw = viv_utils.getShellcodeWorkspaceFromFile(str(sample_path), arch="amd64", analyze=False)
     else:
-        vw = viv_utils.getWorkspace(str(sample_path), analyze=False, should_save=False)
+        vw = _load_workspace_from_file(sample_path)
 
     if file_type is FileType.PE:
         viv_utils.flirt.register_flirt_signature_analyzers(vw, list(map(str, sigpaths)))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -7,6 +7,7 @@ from fixtures import exefile
 
 import floss.main
 import floss.utils
+import floss.pipeline
 
 # floss --no-string-type static -j tests/data/src/decode-in-place/bin/test-decode-in-place.exe
 RESULTS = textwrap.dedent("""
@@ -90,6 +91,14 @@ RESULTS = textwrap.dedent("""
     }
 }
 """)
+
+
+def test_load_vw_ignores_adjacent_viv(tmp_path, exefile):
+    sample = tmp_path / "sample.exe"
+    sample.write_bytes(Path(exefile).read_bytes())
+    sample.with_suffix(".exe.viv").write_bytes(b"not a workspace")
+    vw = floss.pipeline.load_vw(sample, "auto", [])
+    assert vw.getFunctions()
 
 
 def test_load(tmp_path):


### PR DESCRIPTION
## Summary

FLOSS automatically loads `<sample>.viv` when that file exists beside a binary being analysed.

Vivisect workspaces are serialized using Python pickle. Because pickle deserialization can execute code, an attacker who supplies both a binary and a matching `.viv` sidecar can execute code with the analyst's privileges when the analyst runs FLOSS against the binary.

The analyst only needs to select the binary. They do not need to explicitly open the workspace or execute the sample.

## Details

Normal binary analysis currently reaches:

```python
vw = viv_utils.getWorkspace(
    str(sample_path),
    analyze=False,
    should_save=False,
)
```

`viv_utils.getWorkspace()` checks for an adjacent workspace:

```python
viv_file = fp + ".viv"
if os.path.exists(viv_file):
    loadWorkspaceFromViv(vw, viv_file)
```

Vivisect then deserializes the workspace using:

```python
events.extend(pickle.load(f))
```

The complete path is:

```text
floss.pipeline.load_vw
  -> viv_utils.getWorkspace
  -> loadWorkspaceFromViv
  -> VivWorkspace.loadWorkspace
  -> vivisect.storage.basicfile.vivEventsFromFile
  -> pickle.load
```

This creates a trust-boundary problem because FLOSS is intended to analyse attacker-controlled files, while the automatically discovered workspace is treated as trusted serialized state.

## Severity

**CVSS v3.1: 8.8 (High)**  
`CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H`

Exploitation requires an analyst to run FLOSS against an attacker-supplied
binary accompanied by a matching `.viv` sidecar. No explicit workspace
loading or sample execution is required. Successful exploitation results in
arbitrary code execution with the privileges of the FLOSS process.

## Proof

<img width="1240" height="572" alt="windg_image_flare_floss" src="https://github.com/user-attachments/assets/7afa9f9b-d9d4-4e12-ba83-eb10858987ee" />

<img width="1280" height="812" alt="windbg_flare_floss" src="https://github.com/user-attachments/assets/72f8233b-64ca-4072-a9bb-6fd43338b563" />

Confirmed Windows x64 with:

```text
FLOSS:     3.1.1
Commit:    7e1e6e5d3cff6d4a39fa85a0aa508ad3370baa30
viv-utils: 0.8.0
Vivisect:  1.3.1
```

Control:

```text
sample.exe present
sample.exe.viv absent

FLOSS exit code: 0
Child process:   none
Evidence marker: absent
```

Affected case:

```text
sample.exe present
sample.exe.viv present

FLOSS exit code: 0
Child process:   powershell.exe
Evidence marker: present
```

The positive and negative FLOSS output was byte-identical:

```text
SHA-256:
DE5486990EB1B282741277A78EADE5A0DC0032E3989C08FF13475CCA3943DD96
```

WinDbg was configured to follow the FLOSS Python process and break on:

```text
KERNELBASE!CreateProcessW
```

At the relevant breakpoint, `RDX` contained an attacker-controlled PowerShell command.

The native stack reached:

```text
KERNELBASE!CreateProcessW
KERNEL32!CreateProcessWStub
python310!PyEval_EvalFrameDefault
```

Recorded process attribution from a separate run:

```text
ChildName:  powershell.exe
ChildPID:   29708
ParentName: python.exe
ParentPID:  28016
```

## Impact

An attacker who can deliver two adjacent files with matching names can execute code inside of FLOSS when an analyst runs FLOSS against the binary:

```text
sample.exe
sample.exe.viv
```

Potential access is limited to the privileges and resources already available to the FLOSS process, this is unsafe deserialization resulting in arbitrary code execution (`CWE-502`). 

## Fix

This change avoids `viv_utils.getWorkspace()` during ordinary binary analysis.

Instead, FLOSS creates a fresh `VivWorkspace` and calls `loadFromFile()` on the exact path selected by the user. The existing PE parser configuration and Vivisect version metadata are preserved.

Adjacent `.viv` files are therefore ignored during normal analysis.

## Regression test

The added regression test:

1. Copies the existing fast PE fixture.
2. Places a harmless invalid `.viv` file beside it.
3. Runs the real `load_vw()` analysis path.
4. Confirms the PE is analysed successfully.

The vulnerable implementation attempts to deserialize the adjacent workspace and fails. The patched implementation ignores it and analyses only the selected PE.

## Testing

```text
pytest tests/test_load.py
10 passed
```

```text
isort: passed
black: passed
```

Manual validation against the previously confirmed affected input:

```text
FLOSS exit code: 0
Adjacent workspace: ignored
Evidence marker: unchanged
Child process: not created
```

The full local suite completed with:

```text
416 passed
2 skipped
6 expected xfailed
```