### PR TITLE
Emit parseable Python for decoded strings in the Ghidra script

### DIFF
--- a/scripts/disassemblers/render-ghidra-import-script.py
+++ b/scripts/disassemblers/render-ghidra-import-script.py
@@ -223,12 +223,12 @@ def render_ghidra_script(result_document: ResultDocument) -> str:
             b64 = base64.b64encode(ds.string.encode("utf-8")).decode("ascii")
             if ds.address_type == AddressType.GLOBAL:
                 main_commands.append(
-                    f'    print(f"FLOSS: string \\"{{decode_string(\\"{b64}\\")}}\\" at global VA 0x{ds.address:x}")'
+                    f'    print("FLOSS: string \\"" + decode_string("{b64}") + "\\" at global VA 0x{ds.address:x}")'
                 )
                 main_commands.append(f'    append_comment(0x{ds.address:x}, "FLOSS: " + decode_string("{b64}"))')
             else:
                 main_commands.append(
-                    f'    print(f"FLOSS: string \\"{{decode_string(\\"{b64}\\")}}\\" decoded at VA 0x{ds.decoded_at:x}")'
+                    f'    print("FLOSS: string \\"" + decode_string("{b64}") + "\\" decoded at VA 0x{ds.decoded_at:x}")'
                 )
                 main_commands.append(f'    append_comment(0x{ds.decoded_at:x}, "FLOSS: " + decode_string("{b64}"))')
     main_commands.append('    print("Imported decoded strings from FLOSS")')

--- a/tests/test_disassembler_scripts.py
+++ b/tests/test_disassembler_scripts.py
@@ -20,6 +20,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import sys
+import json
 import subprocess
 from pathlib import Path
 from functools import lru_cache
@@ -66,3 +67,35 @@ def test_disassembler_scripts(script, args):
     script_path = get_disassembler_script_path(script)
     p = run_program(script_path, args)
     assert p.returncode == 0
+
+
+def make_result_document(path: Path, address_type: str) -> Path:
+    """Write a minimal result document holding one decoded string."""
+    document = {
+        "metadata": {"file_path": "fixture.exe"},
+        "strings": {
+            "decoded_strings": [
+                {
+                    "address": 4096,
+                    "address_type": address_type,
+                    "string": "DECODED_TEST",
+                    "encoding": "ASCII",
+                    "decoded_at": 4199808,
+                    "decoding_routine": 4199654,
+                }
+            ]
+        },
+    }
+    path.write_text(json.dumps(document))
+    return path
+
+
+@pytest.mark.parametrize("address_type", ["GLOBAL", "STACK"])
+def test_ghidra_script_parses(tmp_path, address_type):
+    """The generated Ghidra script has to be valid Python, not just render cleanly."""
+    results = make_result_document(tmp_path / f"{address_type.lower()}.json", address_type)
+
+    p = run_program(get_disassembler_script_path("render-ghidra-import-script.py"), [str(results)])
+
+    assert p.returncode == 0
+    compile(p.stdout.decode("utf-8"), "apply_floss.py", "exec")


### PR DESCRIPTION
Closes #1351.

`render-ghidra-import-script.py` builds the decoded-string print lines as a nested f-string whose expression contains backslash-escaped quotes, so the generated script comes out as:

```python
print(f"FLOSS: string \"{decode_string(\"REVDT0RFRF9URVNU\")}\" decoded at VA 0x401580")
```

which Python will not parse. The renderer still exits 0, so the failure only shows up when Ghidra, or anything else, tries to load the script.

Reproduced on the current master with the minimal result document from the issue:

```
$ python scripts/disassemblers/render-ghidra-import-script.py results.json > apply_floss.py
$ python -m py_compile apply_floss.py
  File "apply_floss.py", line 160
    print(f"FLOSS: string \"{decode_string(\"REVDT0RFRF9URVNU\")}\" decoded at VA 0x401580")
                                            ^
SyntaxError: unexpected character after line continuation character
```

Both decoded-string branches now concatenate instead of nesting, so the generated line is `print("FLOSS: string \"" + decode_string("...") + "\" decoded at VA 0x401580")`, which parses. The output text is unchanged, and the stack-string and tight-string lines were already built by concatenation and are untouched.

`test_ghidra_script_parses` renders a document with one decoded string, once for each address type, and compiles the output rather than only checking the exit status, which is the gap the issue points at in the existing test. Both parameters fail on master with the SyntaxError above.

`pytest tests/test_disassembler_scripts.py -k ghidra_script_parses` passes, and black and isort are clean on both files with the line length from `.pre-commit-config.yaml`.
